### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,88 @@
+name: Bug Report
+description: Something isn't working as expected
+labels: ["C-Bug", "S-Needs-Triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: When I try to X, Y happens instead of Z.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Create a new instance
+        2. Click "Open Browser"
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the system is affected?
+      multiple: true
+      options:
+        - Agent (container image, systemd, Chrome)
+        - API (REST endpoints, SSE)
+        - Auth (login, sessions, passkeys, RBAC)
+        - Config (settings, openclaw.json, models, API keys)
+        - Dashboard (React frontend, UI)
+        - Deployment (Helm, Docker Compose, installer)
+        - File Manager (browse, read, upload, download)
+        - Logs (SSE log streaming)
+        - Orchestrator (instance lifecycle, volumes)
+        - Proxy (VNC, terminal, chat, WebSocket)
+        - Other / Not sure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      description: What orchestrator backend and host OS?
+      multiple: true
+      options:
+        - Kubernetes
+        - Docker / Docker Compose
+        - Linux
+        - macOS (Docker Desktop)
+        - Windows (Docker Desktop)
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or screenshots
+      description: |
+        Paste logs from `docker logs claworc` or the instance log viewer.
+        Drag and drop screenshots here.
+      render: text
+    validations:
+      required: false
+
+  - type: input
+    id: version
+    attributes:
+      label: Version or commit
+      description: Docker image tag, Helm chart version, or git commit hash.
+      placeholder: "latest / v0.1.0 / abc1234"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Documentation
+    url: https://github.com/gluk-w/claworc/tree/main/docs
+    about: Check the docs before opening an issue

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,49 @@
+name: Feature Request
+description: Suggest new functionality or an improvement
+labels: ["C-Feature", "S-Needs-Triage"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What would you like?
+      description: A clear description of the feature or improvement.
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Why do you need this?
+      description: What problem does this solve? What's your use case?
+      placeholder: I'm trying to do X but currently there's no way to...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the system would this affect?
+      multiple: true
+      options:
+        - Agent (container image, systemd, Chrome)
+        - API (REST endpoints, SSE)
+        - Auth (login, sessions, passkeys, RBAC)
+        - Config (settings, openclaw.json, models, API keys)
+        - Dashboard (React frontend, UI)
+        - Deployment (Helm, Docker Compose, installer)
+        - File Manager (browse, read, upload, download)
+        - Logs (SSE log streaming)
+        - Orchestrator (instance lifecycle, volumes)
+        - Proxy (VNC, terminal, chat, WebSocket)
+        - Other / Not sure
+    validations:
+      required: false
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: If you have ideas on how this could work, describe them here.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -1,0 +1,47 @@
+name: Security Issue
+description: Report a security vulnerability or concern
+labels: ["C-Security", "S-Needs-Triage", "P-High"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        **If this is a critical vulnerability (auth bypass, data exposure, remote code execution), please report it privately via [GitHub Security Advisories](../../security/advisories/new) instead of opening a public issue.**
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is the security concern?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      description: What type of security issue is this?
+      options:
+        - Authentication / Authorization bypass
+        - API key / Secret exposure
+        - Encryption weakness
+        - Container escape / Isolation
+        - Input validation / Injection
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Impact
+      description: What could an attacker do by exploiting this?
+    validations:
+      required: false
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can this be triggered?
+    validations:
+      required: false


### PR DESCRIPTION
## Summary
- Structured form templates for bug reports, feature requests, and security issues
- Dropdowns match the new label taxonomy
- Auto-applies triage labels on submission