### PR TITLE
fix: optional ImagePullSecret and race condition in gateway token setup

### DIFF
--- a/control-plane/internal/orchestrator/orchestrator.go
+++ b/control-plane/internal/orchestrator/orchestrator.go
@@ -67,6 +67,7 @@ type CreateParams struct {
 	ContainerImage  string
 	VNCResolution   string
 	EnvVars         map[string]string
+	ImagePullSecret string
 }
 
 type FileEntry struct {


### PR DESCRIPTION
- Added ImagePullSecret field to CreateParams
- Removed hardcoded ghcr-secret from buildDeployment
- Added waitForGateway helper that polls localhost:18789 via curl
- Wait for gateway readiness before writing token and after restart to prevent "device identity required" on first browser connection
- Increase ReadinessProbe initialDelaySeconds from 30 to 60