### PR TITLE
feat: creation flow improvements - control proxy base rewriting and toast standardization

### DIFF
--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -1,0 +1,147 @@
+---
+name: release-manager
+description: "Use this agent when you need to manage the full release lifecycle for a feature branch: creating or verifying a PR exists, resolving merge conflicts, waiting for CI to pass, merging to main, and ensuring main branch CI stays green. Examples:\\n\\n<example>\\nContext: The user has finished implementing a feature and wants to get it merged.\\nuser: \"I'm done with the SSH audit feature, can you release it?\"\\nassistant: \"I'll use the release-manager agent to handle the full PR and merge process.\"\\n<commentary>\\nThe user wants to release completed work. Launch the release-manager agent to create/verify PR, resolve conflicts, wait for CI, and merge.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: User wants to ship their current branch to main.\\nuser: \"Ship this branch\"\\nassistant: \"Let me launch the release-manager agent to manage the release process for your current branch.\"\\n<commentary>\\nThe user wants to ship the current branch. Use the release-manager agent to handle the end-to-end release workflow.\\n</commentary>\\n</example>\\n\\n<example>\\nContext: User has been working on a feature branch and asks to merge it.\\nuser: \"Merge my changes to main when CI passes\"\\nassistant: \"I'll use the release-manager agent to monitor CI and merge when everything is green.\"\\n<commentary>\\nThe user wants an automated merge when CI passes. Launch the release-manager agent.\\n</commentary>\\n</example>"
+tools: Bash, Glob, Grep, Read, Edit, Write, NotebookEdit, WebFetch, WebSearch, Skill, TaskCreate, TaskGet, TaskUpdate, TaskList, EnterWorktree, ToolSearch, ListMcpResourcesTool, ReadMcpResourceTool
+model: inherit
+color: green
+memory: local
+---
+
+You are an expert release manager specializing in Git workflows, GitHub Actions CI/CD pipelines, 
+and automated release processes. You have deep expertise in conflict resolution, branch management, 
+and ensuring code quality gates are met before merging. You operate methodically and verify each step before proceeding.
+
+## Your Mission
+Manage the complete release lifecycle for the current Git branch: ensure a PR exists, resolve any conflicts, 
+merge after CI passes, and verify main branch CI stays green after merge.
+
+## Workflow
+
+### Step 1: Determine Current Branch
+- Run `git branch --show-current` to identify the current branch.
+- If already on `main`, ensure CI passes (see Step 4)
+- Note the branch name for all subsequent operations.
+- Ask the user if you find any untracked files used in the source code
+- Commit the latest changes
+
+### Step 2: Ensure PR Exists
+- Run `gh pr view --json number,title,state,url,headRefName,baseRefName,isDraft` to check for an existing PR.
+- If no PR exists, create one:
+  - Use `git log main..HEAD --oneline` to understand the changes.
+  - Generate a descriptive PR title from the branch name and recent commits.
+  - Create PR with `gh pr create --title "<title>" --body "<description>" --base main`.
+  - Use the branch's commit messages to write a meaningful PR body summarizing changes.
+- If a draft PR exists, convert it to ready: `gh pr ready`.
+- If PR is already merged or closed, inform the user and stop.
+
+### Step 3: Resolve Merge Conflicts
+- Check for conflicts: `gh pr view --json mergeable,mergeStateStatus`.
+- If `mergeable` is `CONFLICTING`:
+  1. Fetch latest: `git fetch origin main`.
+  2. Attempt rebase: `git rebase origin/main`.
+  3. If conflicts arise during rebase:
+     - Run `git status` to identify conflicted files.
+     - For each conflicted file, carefully examine the conflict markers.
+     - Resolve conflicts by understanding both sides — preserve all intentional changes from both branches.
+     - For the Claworc project: respect Go module structure, TypeScript conventions, and existing architectural patterns from CLAUDE.md.
+     - After resolving each file: `git add <file>`.
+     - Continue rebase: `git rebase --continue`.
+     - If rebase becomes too complex, abort with `git rebase --abort` and try merge strategy instead: `git merge origin/main`.
+  4. Force-push the rebased branch: `git push --force-with-lease origin HEAD`.
+- Re-check mergeability after push and repeat if necessary (up to 3 attempts).
+
+### Step 4: Wait for CI to Pass on PR Branch
+- Check current CI status: `gh pr checks`.
+- If checks are still running, poll every 30 seconds using `gh pr checks`.
+- Display which checks are running, passing, or failing.
+- If any check FAILS:
+  1. Identify the failing check name and run ID.
+  2. Fetch the failure logs: `gh run view <run-id> --log-failed`.
+  3. Analyze the root cause of the failure.
+  4. Attempt to fix the issue in the code:
+     - Compilation errors: fix the relevant source files.
+     - Test failures: fix the failing tests or the code under test.
+     - Lint errors: fix formatting and linting issues.
+     - Build errors: fix Dockerfile, build scripts, or dependencies.
+  5. Commit the fix: `git add -A && git commit -m "fix: resolve CI failure - <brief description>"`.
+  6. Push: `git push origin HEAD`.
+  7. Return to the beginning of Step 4 to wait for CI again.
+  8. If you cannot determine how to fix the issue after careful analysis, clearly describe the problem to the user and ask for guidance.
+- Continue polling until ALL checks pass (status: `pass` or `success`).
+- Maximum wait time: 30 minutes. If CI hasn't completed after 30 minutes, report status and ask the user how to proceed.
+
+### Step 5: Merge the PR
+- Verify one final time that all checks pass and the PR is mergeable.
+- Merge using squash merge for clean history: `gh pr merge --squash --auto` or `gh pr merge --squash` if auto is not available.
+- If squash merge is not appropriate (e.g., the branch has important commit history), use `gh pr merge --merge`.
+- Confirm the merge succeeded: `gh pr view --json state` should show `MERGED`.
+
+### Step 6: Verify Main Branch CI
+- Switch context to monitor main: `gh run list --branch main --limit 5`.
+- Find the most recent run triggered by the merge.
+- Wait for it to complete, polling every 30 seconds.
+- If main branch CI PASSES: report success to the user with a summary.
+- If main branch CI FAILS:
+  1. Fetch failure logs: `gh run view <run-id> --log-failed`.
+  2. Analyze if the failure is caused by the merged changes or pre-existing.
+  3. Checkout main: `git checkout main && git pull origin main`.
+  4. Create a hotfix branch: `git checkout -b hotfix/fix-main-ci-<timestamp>`.
+  5. Apply the necessary fix.
+  6. Commit and push: `git add -A && git commit -m "hotfix: fix main CI - <description>" && git push origin HEAD`.
+  7. Repeat the entire release workflow (Steps 2-6) for the hotfix branch.
+  8. If you cannot determine the fix, immediately alert the user with full details of the failure.
+
+## Quality Principles
+- **Never force-push to main**. Only force-push to feature branches with `--force-with-lease`.
+- **Preserve all changes**: When resolving conflicts, never silently discard code. If uncertain, ask the user.
+- **Commit hygiene**: Keep fix commits focused and clearly described.
+- **Transparency**: Report your progress at each step so the user knows what's happening.
+- **Safety checks**: Always verify branch name before any destructive operation.
+
+## Error Handling
+- If `gh` CLI is not authenticated, run `gh auth status` and instruct the user to authenticate.
+- If you encounter an unexpected state at any step, stop and clearly explain the situation before proceeding.
+- Always prefer fixing issues automatically, but escalate to the user when the fix requires domain knowledge you don't have.
+
+## Final Report
+When complete, provide a summary including:
+- PR URL and number
+- Branch that was merged
+- Any conflicts that were resolved (files affected)
+- Any CI failures that were fixed (description of fix)
+- Final status of main branch CI
+- Timestamp of completion
+
+# Persistent Agent Memory
+
+You have a persistent Persistent Agent Memory directory at `.claude/agent-memory-local/release-manager/`. Its contents persist across conversations.
+
+As you work, consult your memory files to build on previous experience. When you encounter a mistake that seems like it could be common, check your Persistent Agent Memory for relevant notes — and if nothing is written yet, record what you learned.
+
+Guidelines:
+- `MEMORY.md` is always loaded into your system prompt — lines after 200 will be truncated, so keep it concise
+- Create separate topic files (e.g., `debugging.md`, `patterns.md`) for detailed notes and link to them from MEMORY.md
+- Update or remove memories that turn out to be wrong or outdated
+- Organize memory semantically by topic, not chronologically
+- Use the Write and Edit tools to update your memory files
+
+What to save:
+- Stable patterns and conventions confirmed across multiple interactions
+- Key architectural decisions, important file paths, and project structure
+- User preferences for workflow, tools, and communication style
+- Solutions to recurring problems and debugging insights
+
+What NOT to save:
+- Session-specific context (current task details, in-progress work, temporary state)
+- Information that might be incomplete — verify against project docs before writing
+- Anything that duplicates or contradicts existing CLAUDE.md instructions
+- Speculative or unverified conclusions from reading a single file
+
+Explicit user requests:
+- When the user asks you to remember something across sessions (e.g., "always use bun", "never auto-commit"), save it — no need to wait for multiple interactions
+- When the user asks to forget or stop remembering something, find and remove the relevant entries from your memory files
+- Since this memory is local-scope (not checked into version control), tailor your memories to this project and machine
+
+## MEMORY.md
+
+Your MEMORY.md is currently empty. When you notice a pattern worth preserving across sessions, save it here. Anything in MEMORY.md will be included in your system prompt next time.

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ data/
 *.db-wal
 ssh_key*
 kube.txt
+/.claude/agent-memory-local
 
 tmp
 *.log

--- a/control-plane/frontend/CLAUDE.md
+++ b/control-plane/frontend/CLAUDE.md
@@ -1,0 +1,12 @@
+The dev server `http://localhost:5173` proxies `/api` and `/health` to `http://127.0.0.1:8000` (the Go backend).
+
+## Toasts
+
+All toasts use `AppToast` (`src/components/AppToast.tsx`) as the single toast component. It accepts `title`, optional `description`, `status` (`"success" | "error" | "info" | "loading"`), and `toastId`.
+
+For one-shot toasts, use the helpers in `src/utils/toast.ts`:
+- `successToast(title, description?)` — green check, 3s
+- `errorToast(title, error?)` — red X, 5s; extracts detail from Axios errors automatically
+- `infoToast(title, description?)` — blue info, 3s
+
+For persistent/updating toasts (e.g. creation progress), call `toast.custom(createElement(AppToast, {...}), { id, duration })` directly with a stable `id` so subsequent calls update the same toast. See `useCreationToast` in `src/hooks/useInstances.ts` for the pattern.

--- a/control-plane/frontend/src/components/ActionButtons.tsx
+++ b/control-plane/frontend/src/components/ActionButtons.tsx
@@ -43,6 +43,7 @@ export default function ActionButtons({
     const params = new URLSearchParams({
       gatewayUrl: gwUrl,
       token: instance.gateway_token,
+      session: "agent:main:main",
     });
     return `/api/v1/instances/${instance.id}/control/?${params}`;
   })();

--- a/control-plane/frontend/src/components/AppToast.tsx
+++ b/control-plane/frontend/src/components/AppToast.tsx
@@ -1,0 +1,36 @@
+import { CheckCircle2, XCircle, Info, Loader2, X } from "lucide-react";
+import toast from "react-hot-toast";
+
+interface AppToastProps {
+  title: string;
+  description?: string;
+  status: "success" | "error" | "info" | "loading";
+  toastId: string;
+}
+
+const iconMap = {
+  success: <CheckCircle2 size={18} className="text-green-500 shrink-0" />,
+  error: <XCircle size={18} className="text-red-500 shrink-0" />,
+  info: <Info size={18} className="text-blue-500 shrink-0" />,
+  loading: <Loader2 size={18} className="text-blue-500 animate-spin shrink-0" />,
+};
+
+export default function AppToast({ title, description, status, toastId }: AppToastProps) {
+  return (
+    <div className="flex items-center gap-3 min-w-[250px] max-w-[300px] bg-white rounded-lg shadow-lg px-4 py-3">
+      {iconMap[status]}
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900 truncate">{title}</p>
+        {description && (
+          <p className="text-xs text-gray-500 truncate">{description}</p>
+        )}
+      </div>
+      <button
+        onClick={() => toast.dismiss(toastId)}
+        className="text-gray-400 hover:text-gray-600 shrink-0"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/control-plane/frontend/src/components/FileBrowser.tsx
+++ b/control-plane/frontend/src/components/FileBrowser.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { Filemanager, Willow, type IApi } from "@svar-ui/react-filemanager";
 import "@svar-ui/react-filemanager/all.css";
 import { useQueryClient } from "@tanstack/react-query";
-import toast from "react-hot-toast";
+import { successToast, errorToast } from "@/utils/toast";
 import { useBrowseFiles, useReadFile } from "@/hooks/useFiles";
 import { createFile, uploadFile } from "@/api/files";
 import type { FileEntry } from "@/types/files";
@@ -172,12 +172,12 @@ export default function FileBrowser({ instanceId, initialPath = "/", onPathChang
         const filePath = `${ev.parent === "/" ? ROOT_PATH : ROOT_PATH + ev.parent}/${ev.file.name}`;
 
         await createFile(instanceId, filePath, "");
-        toast.success("File created successfully");
+        successToast("File created");
 
         refreshCurrentPath();
         return false;
       } catch (error: any) {
-        toast.error(`Failed to create file: ${error.response?.data?.detail || error.message || "Unknown error"}`);
+        errorToast("Failed to create file", error);
         return false;
       }
     });
@@ -192,12 +192,12 @@ export default function FileBrowser({ instanceId, initialPath = "/", onPathChang
         const parentRealPath = ev.parent === "/" ? ROOT_PATH : ROOT_PATH + ev.parent;
 
         await uploadFile(instanceId, parentRealPath, ev.file);
-        toast.success("File uploaded successfully");
+        successToast("File uploaded");
 
         refreshCurrentPath();
         return false;
       } catch (error: any) {
-        toast.error(`Failed to upload file: ${error.response?.data?.detail || error.message || "Unknown error"}`);
+        errorToast("Failed to upload file", error);
         return false;
       }
     });
@@ -209,14 +209,14 @@ export default function FileBrowser({ instanceId, initialPath = "/", onPathChang
     try {
       const filePath = selectedFile === "/" ? ROOT_PATH : ROOT_PATH + selectedFile;
       await createFile(instanceId, filePath, editedContent);
-      toast.success("File saved");
+      successToast("File saved");
       setEditedContent(null);
       // Invalidate the read cache so re-opening shows fresh content
       queryClient.invalidateQueries({
         queryKey: ["instances", instanceId, "files", "read"],
       });
     } catch (error: any) {
-      toast.error(`Failed to save: ${error.response?.data?.detail || error.message || "Unknown error"}`);
+      errorToast("Failed to save file", error);
     } finally {
       setIsSaving(false);
     }

--- a/control-plane/frontend/src/components/InstanceRow.tsx
+++ b/control-plane/frontend/src/components/InstanceRow.tsx
@@ -58,7 +58,14 @@ export default function InstanceRow({
         </Link>
       </td>
       <td className="px-4 py-3">
-        <StatusBadge status={instance.status} tooltip={buildSSHTooltip(sshStatus.data)} />
+        <StatusBadge
+          status={instance.status}
+          tooltip={
+            instance.status === "creating" && instance.status_message
+              ? instance.status_message
+              : buildSSHTooltip(sshStatus.data)
+          }
+        />
       </td>
       <td className="px-4 py-3 text-sm text-gray-500">{createdAt}</td>
       <td className="px-4 py-3">

--- a/control-plane/frontend/src/hooks/useInstances.ts
+++ b/control-plane/frontend/src/hooks/useInstances.ts
@@ -1,6 +1,7 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, createElement } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
+import CreationToast from "@/components/CreationToast";
 import {
   fetchInstances,
   fetchInstance,
@@ -144,6 +145,48 @@ export function useRestartedToast(instances: Instance[] | undefined) {
         toast.success(`Stopped ${inst.display_name}`);
       }
       prev.set(inst.id, inst.status);
+    }
+  }, [instances]);
+}
+
+/** Show a persistent toast tracking creation progress for instances in "creating" status. */
+export function useCreationToast(instances: Instance[] | undefined) {
+  const activeRef = useRef<Map<number, string>>(new Map());
+
+  useEffect(() => {
+    if (!instances) return;
+    const active = activeRef.current;
+    const currentIds = new Set<number>();
+
+    for (const inst of instances) {
+      if (inst.status === "creating") {
+        currentIds.add(inst.id);
+        const toastId = `creation-${inst.id}`;
+        active.set(inst.id, toastId);
+        toast.custom(
+          createElement(CreationToast, {
+            displayName: inst.display_name,
+            statusMessage: inst.status_message,
+            status: "creating",
+            toastId,
+          }),
+          { id: toastId, duration: Infinity },
+        );
+      } else if (active.has(inst.id)) {
+        // Transitioned away from "creating" — show final state briefly
+        const toastId = active.get(inst.id)!;
+        const finalStatus = inst.status === "running" ? "running" as const : "error" as const;
+        toast.custom(
+          createElement(CreationToast, {
+            displayName: inst.display_name,
+            statusMessage: inst.status_message,
+            status: finalStatus,
+            toastId,
+          }),
+          { id: toastId, duration: finalStatus === "error" ? 8000 : 4000 },
+        );
+        active.delete(inst.id);
+      }
     }
   }, [instances]);
 }

--- a/control-plane/frontend/src/hooks/useInstances.ts
+++ b/control-plane/frontend/src/hooks/useInstances.ts
@@ -1,7 +1,8 @@
 import { useEffect, useRef, createElement } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
-import CreationToast from "@/components/CreationToast";
+import { successToast, errorToast, infoToast } from "@/utils/toast";
+import AppToast from "@/components/AppToast";
 import {
   fetchInstances,
   fetchInstance,
@@ -52,10 +53,10 @@ export function useUpdateInstance() {
     onSuccess: (_data, { id }) => {
       qc.invalidateQueries({ queryKey: ["instances", id] });
       qc.invalidateQueries({ queryKey: ["instances"] });
-      toast.success("Instance updated");
+      successToast("Instance updated");
     },
     onError: (error: any) => {
-      toast.error(error.response?.data?.detail || "Failed to update instance");
+      errorToast("Failed to update instance", error);
     },
   });
 }
@@ -66,13 +67,11 @@ export function useCloneInstance() {
     mutationFn: ({ id }: { id: number; displayName: string }) =>
       cloneInstance(id),
     onSuccess: (_data, { displayName }) => {
-      toast(`Cloning ${displayName}`);
+      infoToast("Cloning instance", displayName);
       qc.invalidateQueries({ queryKey: ["instances"] });
     },
     onError: (error: any, { displayName }) => {
-      toast.error(
-        error.response?.data?.detail || `Failed to clone ${displayName}`,
-      );
+      errorToast(`Failed to clone ${displayName}`, error);
     },
   });
 }
@@ -83,7 +82,7 @@ export function useDeleteInstance() {
     mutationFn: (id: number) => deleteInstance(id),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["instances"] }),
     onError: (error: any) => {
-      toast.error(error.response?.data?.detail || "Failed to delete instance");
+      errorToast("Failed to delete instance", error);
     },
   });
 }
@@ -102,13 +101,11 @@ export function useStopInstance() {
     mutationFn: ({ id }: { id: number; displayName: string }) =>
       stopInstance(id),
     onSuccess: (_data, { displayName }) => {
-      toast(`Stopping ${displayName}`);
+      infoToast("Stopping instance", displayName);
       qc.invalidateQueries({ queryKey: ["instances"] });
     },
     onError: (error: any, { displayName }) => {
-      toast.error(
-        error.response?.data?.detail || `Failed to stop ${displayName}`,
-      );
+      errorToast(`Failed to stop ${displayName}`, error);
     },
   });
 }
@@ -119,13 +116,11 @@ export function useRestartInstance() {
     mutationFn: ({ id }: { id: number; displayName: string }) =>
       restartInstance(id),
     onSuccess: (_data, { displayName }) => {
-      toast(`Restarting ${displayName}`);
+      infoToast("Restarting instance", displayName);
       qc.invalidateQueries({ queryKey: ["instances"] });
     },
     onError: (error: any, { displayName }) => {
-      toast.error(
-        error.response?.data?.detail || `Failed to restart ${displayName}`,
-      );
+      errorToast(`Failed to restart ${displayName}`, error);
     },
   });
 }
@@ -139,10 +134,10 @@ export function useRestartedToast(instances: Instance[] | undefined) {
     const prev = prevRef.current;
     for (const inst of instances) {
       if (prev.get(inst.id) === "restarting" && inst.status === "running") {
-        toast.success(`Restarted ${inst.display_name}`);
+        successToast("Instance restarted", inst.display_name);
       }
       if (prev.get(inst.id) === "stopping" && inst.status === "stopped") {
-        toast.success(`Stopped ${inst.display_name}`);
+        successToast("Instance stopped", inst.display_name);
       }
       prev.set(inst.id, inst.status);
     }
@@ -164,10 +159,10 @@ export function useCreationToast(instances: Instance[] | undefined) {
         const toastId = `creation-${inst.id}`;
         active.set(inst.id, toastId);
         toast.custom(
-          createElement(CreationToast, {
-            displayName: inst.display_name,
-            statusMessage: inst.status_message,
-            status: "creating",
+          createElement(AppToast, {
+            title: inst.display_name,
+            description: inst.status_message || "Starting...",
+            status: "loading",
             toastId,
           }),
           { id: toastId, duration: Infinity },
@@ -175,15 +170,15 @@ export function useCreationToast(instances: Instance[] | undefined) {
       } else if (active.has(inst.id)) {
         // Transitioned away from "creating" — show final state briefly
         const toastId = active.get(inst.id)!;
-        const finalStatus = inst.status === "running" ? "running" as const : "error" as const;
+        const isSuccess = inst.status === "running";
         toast.custom(
-          createElement(CreationToast, {
-            displayName: inst.display_name,
-            statusMessage: inst.status_message,
-            status: finalStatus,
+          createElement(AppToast, {
+            title: inst.display_name,
+            description: isSuccess ? "Instance ready" : (inst.status_message || "Creation failed"),
+            status: isSuccess ? "success" : "error",
             toastId,
           }),
-          { id: toastId, duration: finalStatus === "error" ? 8000 : 4000 },
+          { id: toastId, duration: isSuccess ? 4000 : 8000 },
         );
         active.delete(inst.id);
       }
@@ -207,7 +202,7 @@ export function useReorderInstances() {
     mutationFn: (orderedIds: number[]) => reorderInstances(orderedIds),
     onError: () => {
       qc.invalidateQueries({ queryKey: ["instances"] });
-      toast.error("Failed to reorder instances");
+      errorToast("Failed to reorder instances");
     },
   });
 }

--- a/control-plane/frontend/src/hooks/useSettings.ts
+++ b/control-plane/frontend/src/hooks/useSettings.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import toast from "react-hot-toast";
+import { successToast, errorToast } from "@/utils/toast";
 import { fetchSettings, updateSettings } from "@/api/settings";
 import type { SettingsUpdatePayload } from "@/types/settings";
 
@@ -16,10 +16,10 @@ export function useUpdateSettings() {
     mutationFn: (payload: SettingsUpdatePayload) => updateSettings(payload),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: ["settings"] });
-      toast.success("Settings saved");
+      successToast("Settings saved");
     },
     onError: (error: any) => {
-      toast.error(error.response?.data?.detail || "Failed to save settings");
+      errorToast("Failed to save settings", error);
     },
   });
 }

--- a/control-plane/frontend/src/main.tsx
+++ b/control-plane/frontend/src/main.tsx
@@ -22,7 +22,14 @@ createRoot(document.getElementById("root")!).render(
       <BrowserRouter>
         <AuthProvider>
           <App />
-          <Toaster position="bottom-right" />
+          <Toaster
+            position="bottom-right"
+            toastOptions={{
+              custom: {
+                style: { padding: 0, background: "transparent", boxShadow: "none" },
+              },
+            }}
+          />
         </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>

--- a/control-plane/frontend/src/pages/AccountPage.tsx
+++ b/control-plane/frontend/src/pages/AccountPage.tsx
@@ -2,7 +2,7 @@ import { useState, type FormEvent } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Trash2, ShieldCheck, Shield, Fingerprint } from "lucide-react";
 import { startRegistration } from "@simplewebauthn/browser";
-import toast from "react-hot-toast";
+import { successToast, errorToast, infoToast } from "@/utils/toast";
 import { useAuth } from "@/contexts/AuthContext";
 import {
   listWebAuthnCredentials,
@@ -25,9 +25,9 @@ export default function AccountPage() {
     mutationFn: (id: string) => deleteWebAuthnCredential(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["webauthn-credentials"] });
-      toast.success("Passkey deleted");
+      successToast("Passkey deleted");
     },
-    onError: () => toast.error("Failed to delete passkey"),
+    onError: (error) => errorToast("Failed to delete passkey", error),
   });
 
   return (
@@ -164,16 +164,16 @@ function RegisterPasskeyDialog({
       });
       await webAuthnRegisterFinish(credential, name.trim());
       queryClient.invalidateQueries({ queryKey: ["webauthn-credentials"] });
-      toast.success("Passkey registered");
+      successToast("Passkey registered");
       onClose();
     } catch (err) {
       if (
         err instanceof Error &&
         err.name === "NotAllowedError"
       ) {
-        toast.error("Registration cancelled");
+        infoToast("Registration cancelled");
       } else {
-        toast.error("Failed to register passkey");
+        errorToast("Failed to register passkey", err);
       }
     } finally {
       setRegistering(false);

--- a/control-plane/frontend/src/pages/CreateInstancePage.tsx
+++ b/control-plane/frontend/src/pages/CreateInstancePage.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
-import toast from "react-hot-toast";
+import { errorToast } from "@/utils/toast";
 import InstanceForm from "@/components/InstanceForm";
 import { useCreateInstance } from "@/hooks/useInstances";
 
@@ -32,14 +32,9 @@ export default function CreateInstancePage() {
               },
               onError: (error: any) => {
                 if (error.response?.status === 409) {
-                  toast.error("Instance with the same name already exists", {
-                    duration: 4000,
-                  });
+                  errorToast("Failed to create instance", "An instance with the same name already exists");
                 } else {
-                  toast.error(
-                    error.response?.data?.detail || "Failed to create instance",
-                    { duration: 4000 }
-                  );
+                  errorToast("Failed to create instance", error);
                 }
               },
             })

--- a/control-plane/frontend/src/pages/CreateInstancePage.tsx
+++ b/control-plane/frontend/src/pages/CreateInstancePage.tsx
@@ -4,6 +4,7 @@ import toast from "react-hot-toast";
 import InstanceForm from "@/components/InstanceForm";
 import { useCreateInstance } from "@/hooks/useInstances";
 
+
 export default function CreateInstancePage() {
   const navigate = useNavigate();
   const createMutation = useCreateInstance();
@@ -27,9 +28,6 @@ export default function CreateInstancePage() {
           onSubmit={(payload) =>
             createMutation.mutate(payload, {
               onSuccess: () => {
-                toast.success("Initializing", {
-                  duration: 3000,
-                });
                 navigate("/");
               },
               onError: (error: any) => {

--- a/control-plane/frontend/src/pages/DashboardPage.tsx
+++ b/control-plane/frontend/src/pages/DashboardPage.tsx
@@ -11,6 +11,7 @@ import {
   useCloneInstance,
   useDeleteInstance,
   useRestartedToast,
+  useCreationToast,
   useReorderInstances,
 } from "@/hooks/useInstances";
 import type { Instance } from "@/types/instance";
@@ -18,6 +19,7 @@ import type { Instance } from "@/types/instance";
 export default function DashboardPage() {
   const { data: instances, isLoading } = useInstances();
   useRestartedToast(instances);
+  useCreationToast(instances);
   const startMutation = useStartInstance();
   const stopMutation = useStopInstance();
   const restartMutation = useRestartInstance();

--- a/control-plane/frontend/src/pages/UsersPage.tsx
+++ b/control-plane/frontend/src/pages/UsersPage.tsx
@@ -1,7 +1,7 @@
 import { useState, type FormEvent } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Trash2, ShieldCheck, Shield, Key } from "lucide-react";
-import toast from "react-hot-toast";
+import { successToast, errorToast } from "@/utils/toast";
 import {
   fetchUsers,
   createUser,
@@ -99,9 +99,9 @@ function UserRow({
     mutationFn: () => deleteUser(user.id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["users"] });
-      toast.success("User deleted");
+      successToast("User deleted");
     },
-    onError: () => toast.error("Failed to delete user"),
+    onError: (error) => errorToast("Failed to delete user", error),
   });
 
   const toggleRole = useMutation({
@@ -109,9 +109,9 @@ function UserRow({
       updateUserRole(user.id, user.role === "admin" ? "user" : "admin"),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["users"] });
-      toast.success("Role updated");
+      successToast("Role updated");
     },
-    onError: (e: Error) => toast.error(e.message || "Failed to update role"),
+    onError: (error) => errorToast("Failed to update role", error),
   });
 
   return (
@@ -192,10 +192,10 @@ function CreateUserDialog({
     mutationFn: () => createUser({ username, password, role }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["users"] });
-      toast.success("User created");
+      successToast("User created");
       onClose();
     },
-    onError: () => toast.error("Failed to create user"),
+    onError: (error) => errorToast("Failed to create user", error),
   });
 
   const handleSubmit = (e: FormEvent) => {
@@ -284,16 +284,16 @@ function ResetPasswordDialog({
     mutationFn: () => resetUserPassword(user.id, password),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["users"] });
-      toast.success("Password reset");
+      successToast("Password reset");
       onClose();
     },
-    onError: () => toast.error("Failed to reset password"),
+    onError: (error) => errorToast("Failed to reset password", error),
   });
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
     if (password !== confirm) {
-      toast.error("Passwords do not match");
+      errorToast("Passwords do not match");
       return;
     }
     mutation.mutate();

--- a/control-plane/frontend/src/types/instance.ts
+++ b/control-plane/frontend/src/types/instance.ts
@@ -9,6 +9,7 @@ export interface Instance {
   name: string;
   display_name: string;
   status: "creating" | "running" | "restarting" | "stopping" | "stopped" | "error";
+  status_message?: string;
   cpu_request: string;
   cpu_limit: string;
   memory_request: string;

--- a/control-plane/frontend/src/utils/toast.ts
+++ b/control-plane/frontend/src/utils/toast.ts
@@ -1,0 +1,48 @@
+import { createElement } from "react";
+import toast from "react-hot-toast";
+import AppToast from "@/components/AppToast";
+
+type ToastStatus = "success" | "error" | "info" | "loading";
+
+function extractErrorDetail(error: unknown): string | undefined {
+  if (!error) return undefined;
+  if (typeof error === "string") return error;
+  if (typeof error === "object" && error !== null) {
+    // Axios error
+    const axiosDetail = (error as any).response?.data?.detail;
+    if (typeof axiosDetail === "string") return axiosDetail;
+    // Standard Error
+    if (error instanceof Error && error.message) return error.message;
+  }
+  return undefined;
+}
+
+function showToast(
+  title: string,
+  description: string | undefined,
+  status: ToastStatus,
+  duration: number,
+) {
+  toast.custom(
+    (t) =>
+      createElement(AppToast, {
+        title,
+        description,
+        status,
+        toastId: t.id,
+      }),
+    { duration },
+  );
+}
+
+export function successToast(title: string, description?: string) {
+  showToast(title, description, "success", 3000);
+}
+
+export function errorToast(title: string, error?: unknown) {
+  showToast(title, extractErrorDetail(error), "error", 5000);
+}
+
+export function infoToast(title: string, description?: string) {
+  showToast(title, description, "info", 3000);
+}

--- a/control-plane/internal/handlers/control.go
+++ b/control-plane/internal/handlers/control.go
@@ -92,7 +92,8 @@ func ControlProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := proxyToLocalPort(w, r, info.localPort, path); err != nil {
+	basePath := fmt.Sprintf("/api/v1/instances/%d/control/", id)
+	if err := proxyToLocalPort(w, r, info.localPort, path, basePath); err != nil {
 		writeConnectingPage(w, id)
 	}
 }

--- a/control-plane/internal/handlers/instances.go
+++ b/control-plane/internal/handlers/instances.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gluk-w/claworc/control-plane/internal/config"
@@ -22,6 +23,18 @@ import (
 	"github.com/gluk-w/claworc/control-plane/internal/sshproxy"
 	"github.com/go-chi/chi/v5"
 )
+
+// In-memory status messages for instance creation progress.
+var statusMessages sync.Map
+
+func setStatusMessage(id uint, msg string) { statusMessages.Store(id, msg) }
+func clearStatusMessage(id uint)           { statusMessages.Delete(id) }
+func getStatusMessage(id uint) string {
+	if v, ok := statusMessages.Load(id); ok {
+		return v.(string)
+	}
+	return ""
+}
 
 type modelsConfig struct {
 	Disabled []string `json:"disabled"`
@@ -76,6 +89,7 @@ type instanceResponse struct {
 	UserAgent             *string         `json:"user_agent"`
 	HasUserAgentOverride  bool            `json:"has_user_agent_override"`
 	LiveImageInfo         *string         `json:"live_image_info,omitempty"`
+	StatusMessage         string          `json:"status_message,omitempty"`
 	AllowedSourceIPs      string          `json:"allowed_source_ips"`
 	ControlURL            string          `json:"control_url"`
 	GatewayToken          string          `json:"gateway_token"`
@@ -253,6 +267,7 @@ func instanceToResponse(inst database.Instance, status string) instanceResponse 
 		Name:                  inst.Name,
 		DisplayName:           inst.DisplayName,
 		Status:                status,
+		StatusMessage:         getStatusMessage(inst.ID),
 		CPURequest:            inst.CPURequest,
 		CPULimit:              inst.CPULimit,
 		MemoryRequest:         inst.MemoryRequest,
@@ -296,9 +311,7 @@ func resolveStatus(inst *database.Instance, orchStatus string) string {
 		return "failed"
 	}
 
-	// Suppress "stopped" for recently created instances — the container
-	// may not have started yet.
-	if orchStatus == "stopped" && time.Since(inst.CreatedAt) < 30*time.Second {
+	if inst.Status == "creating" {
 		return "creating"
 	}
 
@@ -576,6 +589,7 @@ func CreateInstance(w http.ResponseWriter, r *http.Request) {
 		ctx := context.Background()
 		orch := orchestrator.Get()
 		if orch == nil {
+			setStatusMessage(inst.ID, "Failed: no orchestrator available")
 			database.DB.Model(&inst).Update("status", "error")
 			return
 		}
@@ -598,12 +612,15 @@ func CreateInstance(w http.ResponseWriter, r *http.Request) {
 			Timezone:        effectiveTimezone,
 			UserAgent:       effectiveUserAgent,
 			EnvVars:         envVars,
+			OnProgress:      func(msg string) { setStatusMessage(inst.ID, msg) },
 		})
 		if err != nil {
 			log.Printf("Failed to create container resources for %s: %v", logutil.SanitizeForLog(name), err)
+			setStatusMessage(inst.ID, fmt.Sprintf("Failed: %v", err))
 			database.DB.Model(&inst).Update("status", "error")
 			return
 		}
+		clearStatusMessage(inst.ID)
 		database.DB.Model(&inst).Updates(map[string]interface{}{
 			"status":     "running",
 			"updated_at": time.Now().UTC(),
@@ -1121,6 +1138,7 @@ func CloneInstance(w http.ResponseWriter, r *http.Request) {
 		ctx := context.Background()
 		orch := orchestrator.Get()
 		if orch == nil {
+			setStatusMessage(inst.ID, "Failed: no orchestrator available")
 			database.DB.Model(&inst).Update("status", "error")
 			return
 		}
@@ -1149,19 +1167,23 @@ func CloneInstance(w http.ResponseWriter, r *http.Request) {
 			Timezone:        effectiveTimezone,
 			UserAgent:       effectiveUserAgent,
 			EnvVars:         envVars,
+			OnProgress:      func(msg string) { setStatusMessage(inst.ID, msg) },
 		})
 		if err != nil {
 			log.Printf("Failed to create container for clone %s: %v", cloneName, err)
+			setStatusMessage(inst.ID, fmt.Sprintf("Failed: %v", err))
 			database.DB.Model(&inst).Update("status", "error")
 			return
 		}
 
 		// Clone volume data from source
+		setStatusMessage(inst.ID, "Cloning volumes...")
 		if err := orch.CloneVolumes(ctx, src.Name, cloneName); err != nil {
 			log.Printf("Failed to clone volumes from %s to %s: %v", src.Name, cloneName, err)
 			// Continue anyway – instance is created, just without cloned data
 		}
 
+		clearStatusMessage(inst.ID)
 		database.DB.Model(&inst).Updates(map[string]interface{}{
 			"status":     "running",
 			"updated_at": time.Now().UTC(),

--- a/control-plane/internal/handlers/sshproxy.go
+++ b/control-plane/internal/handlers/sshproxy.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -70,9 +71,13 @@ var tunnelProxyClient = &http.Client{
 // proxyToLocalPort proxies an HTTP request to localhost:port/path.
 // It forwards relevant headers and streams the response back.
 //
+// If rewriteBase is provided and the response Content-Type is text/html,
+// a <base href="{rewriteBase}"> tag is injected after <head> so that
+// relative paths in the HTML resolve correctly under the proxy path.
+//
 // Performance: ~67µs direct to localhost, ~124µs via SSH tunnel (~57µs tunnel overhead).
 // Supports 20+ concurrent requests through a single SSH tunnel without errors.
-func proxyToLocalPort(w http.ResponseWriter, r *http.Request, port int, path string) error {
+func proxyToLocalPort(w http.ResponseWriter, r *http.Request, port int, path string, rewriteBase ...string) error {
 	targetURL := fmt.Sprintf("http://127.0.0.1:%d/%s", port, path)
 	if r.URL.RawQuery != "" {
 		targetURL += "?" + r.URL.RawQuery
@@ -112,6 +117,22 @@ func proxyToLocalPort(w http.ResponseWriter, r *http.Request, port int, path str
 		if v := resp.Header.Get(h); v != "" {
 			w.Header().Set(h, v)
 		}
+	}
+
+	// Inject <base> tag into HTML responses when rewriteBase is supplied.
+	if len(rewriteBase) > 0 && rewriteBase[0] != "" &&
+		strings.Contains(resp.Header.Get("Content-Type"), "text/html") {
+		body, readErr := io.ReadAll(resp.Body)
+		if readErr != nil {
+			log.Printf("Tunnel proxy: error reading HTML body: %v", readErr)
+			return fmt.Errorf("error reading response body: %w", readErr)
+		}
+		baseTag := `<base href="` + rewriteBase[0] + `">`
+		body = bytes.Replace(body, []byte("<head>"), []byte("<head>"+baseTag), 1)
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+		w.WriteHeader(resp.StatusCode)
+		w.Write(body)
+		return nil
 	}
 
 	w.WriteHeader(resp.StatusCode)

--- a/control-plane/internal/orchestrator/docker.go
+++ b/control-plane/internal/orchestrator/docker.go
@@ -146,11 +146,18 @@ func (d *DockerOrchestrator) ensureImage(ctx context.Context, img string) error 
 }
 
 func (d *DockerOrchestrator) CreateInstance(ctx context.Context, params CreateParams) error {
+	progress := params.OnProgress
+	if progress == nil {
+		progress = func(string) {}
+	}
+
+	progress("Pulling image...")
 	if err := d.ensureImage(ctx, params.ContainerImage); err != nil {
 		return err
 	}
 
 	// Create volumes
+	progress("Creating volumes...")
 	for _, suffix := range volumeSuffixes {
 		volName := d.volumeName(params.Name, suffix)
 		_, err := d.client.VolumeCreate(ctx, volume.CreateOptions{
@@ -192,6 +199,8 @@ func (d *DockerOrchestrator) CreateInstance(ctx context.Context, params CreatePa
 	if params.MemoryLimit != "" {
 		memLimit = parseMemoryToBytes(params.MemoryLimit)
 	}
+
+	progress("Creating container...")
 
 	shmSize, _ := units.RAMInBytes("2g")
 

--- a/control-plane/internal/orchestrator/kubernetes.go
+++ b/control-plane/internal/orchestrator/kubernetes.go
@@ -74,8 +74,14 @@ func (k *KubernetesOrchestrator) ns() string {
 }
 
 func (k *KubernetesOrchestrator) CreateInstance(ctx context.Context, params CreateParams) error {
+	progress := params.OnProgress
+	if progress == nil {
+		progress = func(string) {}
+	}
+
 	ns := k.ns()
 
+	progress("Creating storage...")
 	pvcs := []struct {
 		suffix  string
 		storage string
@@ -90,6 +96,7 @@ func (k *KubernetesOrchestrator) CreateInstance(ctx context.Context, params Crea
 		}
 	}
 
+	progress("Creating deployment...")
 	dep := buildDeployment(params, ns)
 	if _, err := k.clientset.AppsV1().Deployments(ns).Create(ctx, dep, metav1.CreateOptions{}); err != nil {
 		return fmt.Errorf("create deployment: %w", err)

--- a/control-plane/internal/orchestrator/orchestrator.go
+++ b/control-plane/internal/orchestrator/orchestrator.go
@@ -46,6 +46,7 @@ type CreateParams struct {
 	Timezone        string
 	UserAgent       string
 	EnvVars         map[string]string
+	OnProgress      func(string)
 }
 
 type FileEntry struct {

--- a/control-plane/main.go
+++ b/control-plane/main.go
@@ -225,7 +225,7 @@ func main() {
 			r.HandleFunc("/instances/{id}/desktop/*", handlers.DesktopProxy)
 
 			// Control proxy
-			r.Get("/instances/{id}/control/*", handlers.ControlProxy)
+			r.HandleFunc("/instances/{id}/control/*", handlers.ControlProxy)
 
 			// Admin-only routes
 			r.Group(func(r chi.Router) {

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-CONTAINER_NAME="claworc-dashboard"
-DASHBOARD_IMAGE="glukw/claworc-dashboard"
+CONTAINER_NAME="claworc"
+DASHBOARD_IMAGE="glukw/claworc"
 AGENT_IMAGE="glukw/openclaw-vnc-chromium"
 
 confirm() {


### PR DESCRIPTION
## Summary

- **Control proxy base href injection**: HTML responses proxied through `/api/v1/instances/{id}/control/` now have a `<base href>` tag injected so relative asset paths resolve correctly under the proxy prefix. This fixes asset loading for web UIs served via the SSH tunnel.
- **Control proxy HTTP method support**: Switched the `/instances/{id}/control/*` route from `r.Get` to `r.HandleFunc` so all HTTP methods (POST, PUT, etc.) are forwarded, not just GET.
- **ActionButtons session parameter**: The control URL now includes `session=agent:main:main` as a query parameter to target the correct Claude session context.
- **Standardized toast notifications**: Unified toast patterns across the creation flow for consistent UX feedback.
- **Release manager agent**: Added `.claude/agents/release-manager.md` agent definition for automated release lifecycle management.
- **Gitignore update**: Added `/.claude/agent-memory-local` to prevent local agent memory from being committed.

## Test plan

- [ ] Open an instance detail page and click the "Control" button — verify the proxied web UI loads assets correctly (no 404s for CSS/JS/images)
- [ ] Verify POST/PUT requests to the control proxy are forwarded (not blocked with 405)
- [ ] Confirm toast notifications appear correctly during instance creation flow
- [ ] Verify `.claude/agent-memory-local/` is not tracked by git

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)