### PR TITLE
ci: fix path filters, add test jobs, and website worker workflow

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'agent'
+      - 'agent/**'
       - '.github/workflows/agent.yml'
 
 jobs:

--- a/.github/workflows/control-plane.yml
+++ b/.github/workflows/control-plane.yml
@@ -1,14 +1,50 @@
-name: Build and Push Control Plane Image
+name: Control Plane
 
 on:
   push:
-    branches: [main]
     paths:
-      - 'control-plane'
+      - 'control-plane/**'
       - '.github/workflows/control-plane.yml'
 
 jobs:
-  control-plane:
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: control-plane/go.mod
+
+      - name: Run unit tests
+        uses: robherley/go-test-action@v0
+        with:
+          moduleDirectory: control-plane
+          testarguments: ./internal/...
+
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: control-plane/go.mod
+
+      - name: Run integration tests
+        uses: robherley/go-test-action@v0
+        with:
+          moduleDirectory: control-plane
+          testarguments: -tags docker_integration -timeout 600s -count=1 ./internal/handlers/ -run TestIntegration
+        env:
+          CLAWORC_LLM_GATEWAY_PORT: 40001
+
+  push:
+    name: Build and Push Image
+    if: github.ref == 'refs/heads/main'
+    needs: [unit, integration]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/worker.yml
+++ b/.github/workflows/worker.yml
@@ -1,0 +1,20 @@
+name: Website Worker
+
+on:
+  push:
+    paths:
+      - 'website/worker/**'
+      - '.github/workflows/worker.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run tests
+        run: make worker-test


### PR DESCRIPTION
## Summary

- **agent.yml**: Fix path filter from `agent` to `agent/**` so changes inside the directory correctly trigger the workflow
- **control-plane.yml**: Major overhaul — fix path filter to `control-plane/**`, add `unit` and `integration` test jobs, gate the image push job behind tests passing, restrict push only to main branch
- **worker.yml**: New workflow to run tests for `website/worker/**` changes

These changes were part of the `llm-usage-page` branch but were not included in the squash merge to main (PR #35 used a fresh branch + diff approach that missed `.github/` files).

## Test plan

- [ ] Verify CodeQL passes (no path filter — runs on all PRs)
- [ ] Verify the PR itself does not trigger `control-plane` or `agent` builds (path filters should not match)
- [ ] After merge, confirm main branch CI runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)