### PR TITLE
feat: improve login UX and add change password

### DIFF
--- a/control-plane/frontend/src/App.tsx
+++ b/control-plane/frontend/src/App.tsx
@@ -55,7 +55,7 @@ export default function App() {
           }
         />
         <Route path="/instances/:id" element={<InstanceDetailPage />} />
-        <Route path="/account" element={<AccountPage />} />
+        <Route path="/profile" element={<AccountPage />} />
         <Route
           path="/settings"
           element={

--- a/control-plane/frontend/src/api/auth.ts
+++ b/control-plane/frontend/src/api/auth.ts
@@ -62,3 +62,7 @@ export async function listWebAuthnCredentials(): Promise<WebAuthnCredential[]> {
 export async function deleteWebAuthnCredential(id: string): Promise<void> {
   await client.delete(`/auth/webauthn/credentials/${encodeURIComponent(id)}`);
 }
+
+export async function changePassword(data: { current_password: string; new_password: string }): Promise<void> {
+  await client.post("/auth/change-password", data);
+}

--- a/control-plane/frontend/src/components/Sidebar.tsx
+++ b/control-plane/frontend/src/components/Sidebar.tsx
@@ -135,9 +135,9 @@ export default function Sidebar() {
       {/* User section */}
       <div className="px-3 pb-4 border-t border-gray-200 pt-3 shrink-0">
         <Link
-          to="/account"
+          to="/profile"
           className={`flex items-center gap-3 px-3 py-2.5 rounded-lg transition-colors ${
-            isActive("/account")
+            isActive("/profile")
               ? "bg-blue-50 text-blue-700 font-medium"
               : "text-gray-600 hover:text-gray-900 hover:bg-gray-100"
           }`}

--- a/control-plane/frontend/src/pages/AccountPage.tsx
+++ b/control-plane/frontend/src/pages/AccountPage.tsx
@@ -1,6 +1,6 @@
 import { useState, type FormEvent } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Trash2, ShieldCheck, Shield, Fingerprint } from "lucide-react";
+import { Trash2, ShieldCheck, Shield, Fingerprint, KeyRound } from "lucide-react";
 import { startRegistration } from "@simplewebauthn/browser";
 import { successToast, errorToast, infoToast } from "@/utils/toast";
 import { useAuth } from "@/contexts/AuthContext";
@@ -9,12 +9,14 @@ import {
   deleteWebAuthnCredential,
   webAuthnRegisterBegin,
   webAuthnRegisterFinish,
+  changePassword,
 } from "@/api/auth";
 
 export default function AccountPage() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
   const [showRegister, setShowRegister] = useState(false);
+  const [showChangePassword, setShowChangePassword] = useState(false);
 
   const { data: credentials = [], isLoading } = useQuery({
     queryKey: ["webauthn-credentials"],
@@ -32,30 +34,39 @@ export default function AccountPage() {
 
   return (
     <div>
-      <h1 className="text-xl font-semibold text-gray-900 mb-6">Account</h1>
+      <h1 className="text-xl font-semibold text-gray-900 mb-6">Profile</h1>
 
       <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
         <h2 className="text-sm font-medium text-gray-500 mb-3">
           Account Info
         </h2>
-        <div className="flex items-center gap-3">
-          <span className="text-lg font-medium text-gray-900">
-            {user?.username}
-          </span>
-          <span
-            className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${
-              user?.role === "admin"
-                ? "bg-purple-50 text-purple-700"
-                : "bg-gray-100 text-gray-600"
-            }`}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <span className="text-lg font-medium text-gray-900">
+              {user?.username}
+            </span>
+            <span
+              className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium rounded-full ${
+                user?.role === "admin"
+                  ? "bg-purple-50 text-purple-700"
+                  : "bg-gray-100 text-gray-600"
+              }`}
+            >
+              {user?.role === "admin" ? (
+                <ShieldCheck size={12} />
+              ) : (
+                <Shield size={12} />
+              )}
+              {user?.role}
+            </span>
+          </div>
+          <button
+            onClick={() => setShowChangePassword(true)}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 border border-gray-300 rounded-md hover:bg-gray-50"
           >
-            {user?.role === "admin" ? (
-              <ShieldCheck size={12} />
-            ) : (
-              <Shield size={12} />
-            )}
-            {user?.role}
-          </span>
+            <KeyRound size={16} />
+            Change Password
+          </button>
         </div>
       </div>
 
@@ -138,6 +149,10 @@ export default function AccountPage() {
           queryClient={queryClient}
         />
       )}
+
+      {showChangePassword && (
+        <ChangePasswordDialog onClose={() => setShowChangePassword(false)} />
+      )}
     </div>
   );
 }
@@ -213,6 +228,114 @@ function RegisterPasskeyDialog({
               className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
             >
               {registering ? "Registering..." : "Register"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function ChangePasswordDialog({ onClose }: { onClose: () => void }) {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError("");
+
+    if (newPassword !== confirmPassword) {
+      setError("New passwords do not match");
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await changePassword({
+        current_password: currentPassword,
+        new_password: newPassword,
+      });
+      successToast("Password changed successfully");
+      onClose();
+    } catch (err) {
+      errorToast("Failed to change password", err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
+    >
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-sm p-6">
+        <h2 className="text-lg font-semibold mb-4">Change Password</h2>
+
+        {error && (
+          <div className="mb-3 p-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded-md">
+            {error}
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Current Password
+            </label>
+            <input
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              required
+              autoFocus
+              autoComplete="current-password"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              New Password
+            </label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              required
+              autoComplete="new-password"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Confirm New Password
+            </label>
+            <input
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              required
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-1.5 text-sm text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
+            >
+              {saving ? "Saving..." : "Change Password"}
             </button>
           </div>
         </form>

--- a/control-plane/frontend/src/pages/LoginPage.tsx
+++ b/control-plane/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { Fingerprint } from "lucide-react";
+import { isAxiosError } from "axios";
 import { useAuth } from "@/contexts/AuthContext";
 import {
   checkSetupRequired,
@@ -10,6 +11,33 @@ import {
 } from "@/api/auth";
 import { startAuthentication } from "@simplewebauthn/browser";
 import type { PublicKeyCredentialRequestOptionsJSON } from "@simplewebauthn/browser";
+
+function getLoginError(error: unknown): string {
+  if (isAxiosError(error)) {
+    if (!error.response) {
+      return "Unable to connect to the server. Please check your connection.";
+    }
+    const status = error.response.status;
+    if (status === 401) return "Invalid username or password";
+    if (status >= 500) return "Something went wrong. Please try again later.";
+    const detail = error.response.data?.detail;
+    if (typeof detail === "string") return detail;
+  }
+  return "Something went wrong. Please try again later.";
+}
+
+function getSetupError(error: unknown): string {
+  if (isAxiosError(error)) {
+    if (!error.response) {
+      return "Unable to connect to the server. Please check your connection.";
+    }
+    const status = error.response.status;
+    if (status >= 500) return "Something went wrong. Please try again later.";
+    const detail = error.response.data?.detail;
+    if (typeof detail === "string") return detail;
+  }
+  return "Failed to create admin account";
+}
 
 export default function LoginPage() {
   const { login, refetch } = useAuth();
@@ -50,12 +78,8 @@ export default function LoginPage() {
         await login({ username, password });
         navigate("/");
       }
-    } catch {
-      setError(
-        setupMode
-          ? "Failed to create admin account"
-          : "Invalid username or password",
-      );
+    } catch (err) {
+      setError(setupMode ? getSetupError(err) : getLoginError(err));
     } finally {
       setLoading(false);
     }
@@ -72,8 +96,12 @@ export default function LoginPage() {
       await webAuthnLoginFinish(result);
       refetch();
       navigate("/");
-    } catch {
-      setError("Passkey authentication failed");
+    } catch (err) {
+      if (isAxiosError(err) && !err.response) {
+        setError("Unable to connect to the server. Please check your connection.");
+      } else {
+        setError("Passkey authentication failed");
+      }
     } finally {
       setLoading(false);
     }

--- a/control-plane/internal/auth/auth.go
+++ b/control-plane/internal/auth/auth.go
@@ -84,6 +84,16 @@ func (s *SessionStore) DeleteByUserID(userID uint) {
 	s.mu.Unlock()
 }
 
+func (s *SessionStore) DeleteByUserIDExcept(userID uint, exceptSessionID string) {
+	s.mu.Lock()
+	for id, entry := range s.sessions {
+		if entry.UserID == userID && id != exceptSessionID {
+			delete(s.sessions, id)
+		}
+	}
+	s.mu.Unlock()
+}
+
 func (s *SessionStore) Cleanup() {
 	now := time.Now()
 	s.mu.Lock()

--- a/control-plane/internal/handlers/auth.go
+++ b/control-plane/internal/handlers/auth.go
@@ -160,6 +160,58 @@ func SetupCreateAdmin(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func ChangePassword(w http.ResponseWriter, r *http.Request) {
+	user := middleware.GetUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+
+	var body struct {
+		CurrentPassword string `json:"current_password"`
+		NewPassword     string `json:"new_password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid request body")
+		return
+	}
+
+	if body.CurrentPassword == "" || body.NewPassword == "" {
+		writeError(w, http.StatusBadRequest, "Current password and new password are required")
+		return
+	}
+
+	dbUser, err := database.GetUserByID(user.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "Failed to load user")
+		return
+	}
+
+	if !auth.CheckPassword(body.CurrentPassword, dbUser.PasswordHash) {
+		writeError(w, http.StatusUnauthorized, "Current password is incorrect")
+		return
+	}
+
+	hash, err := auth.HashPassword(body.NewPassword)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "Failed to hash password")
+		return
+	}
+
+	if err := database.UpdateUserPassword(user.ID, hash); err != nil {
+		writeError(w, http.StatusInternalServerError, "Failed to update password")
+		return
+	}
+
+	// Invalidate all other sessions for this user
+	cookie, err := r.Cookie(auth.SessionCookie)
+	if err == nil {
+		SessionStore.DeleteByUserIDExcept(user.ID, cookie.Value)
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
 // WebAuthn handlers
 
 func WebAuthnRegisterBegin(w http.ResponseWriter, r *http.Request) {

--- a/control-plane/main.go
+++ b/control-plane/main.go
@@ -206,6 +206,7 @@ func main() {
 
 			r.Post("/auth/logout", handlers.Logout)
 			r.Get("/auth/me", handlers.GetCurrentUser)
+			r.Post("/auth/change-password", handlers.ChangePassword)
 			r.Post("/auth/webauthn/register/begin", handlers.WebAuthnRegisterBegin)
 			r.Post("/auth/webauthn/register/finish", handlers.WebAuthnRegisterFinish)
 			r.Get("/auth/webauthn/credentials", handlers.ListWebAuthnCredentials)


### PR DESCRIPTION
## Summary

- Add a **Change Password** feature: new backend endpoint (`POST /auth/change-password`) with current password verification, password update, and session invalidation for other sessions
- Improve **login error messages**: replace generic catch-all errors with context-specific messages (connection failure, invalid credentials, server error) using Axios error inspection
- Improve **passkey authentication** error handling with network-aware messages
- Rename the "Account" page to "Profile" and update the route from `/account` to `/profile`
- Add `DeleteByUserIDExcept` session store method to invalidate all sessions except the current one after password change

## Changes

- `control-plane/internal/handlers/auth.go` — new `ChangePassword` handler
- `control-plane/internal/auth/auth.go` — new `DeleteByUserIDExcept` method on SessionStore
- `control-plane/main.go` — register the `/auth/change-password` route
- `control-plane/frontend/src/api/auth.ts` — new `changePassword` API function
- `control-plane/frontend/src/pages/LoginPage.tsx` — `getLoginError` / `getSetupError` helpers for user-friendly messages
- `control-plane/frontend/src/pages/AccountPage.tsx` — `ChangePasswordDialog` component, page renamed to Profile
- `control-plane/frontend/src/App.tsx` — route changed `/account` -> `/profile`
- `control-plane/frontend/src/components/Sidebar.tsx` — sidebar link updated to `/profile`

## Test plan

- [ ] Verify login with invalid credentials shows "Invalid username or password"
- [ ] Verify login with server down shows connection error message
- [ ] Verify Change Password dialog opens from Profile page
- [ ] Verify password change with correct current password succeeds
- [ ] Verify password change with wrong current password shows error
- [ ] Verify other sessions are invalidated after password change
- [ ] Verify passkey auth failure with network issues shows appropriate message

🤖 Generated with [Claude Code](https://claude.com/claude-code)