### PR TITLE
Fix service worker intercepting /openclaw/ navigation

### DIFF
--- a/control-plane/frontend/src/components/ActionButtons.tsx
+++ b/control-plane/frontend/src/components/ActionButtons.tsx
@@ -39,7 +39,8 @@ export default function ActionButtons({
   const isUnavailable = !isRunning;
 
   const controlUrl = (() => {
-    const gwUrl = `ws://${window.location.host}/openclaw/${instance.id}/`;
+    const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const gwUrl = `${wsProtocol}//${window.location.host}/openclaw/${instance.id}/`;
     const params = new URLSearchParams({
       gatewayUrl: gwUrl,
       token: instance.gateway_token,

--- a/control-plane/frontend/vite.config.ts
+++ b/control-plane/frontend/vite.config.ts
@@ -61,8 +61,10 @@ export default defineConfig({
       },
       workbox: {
         globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
-        navigateFallback: "/index.html",
-        navigateFallbackDenylist: [/^\/api\//, /^\/health/, /^\/openclaw\//],
+        // No navigateFallback — server handles SPA routing.
+        // This prevents the SW from intercepting navigation to /openclaw/.
+        // Must be explicitly null to override VitePWA's default of "index.html".
+        navigateFallback: null,
         runtimeCaching: [
           {
             urlPattern: /^https?:\/\/.*\/(api|openclaw)\//,

--- a/control-plane/internal/orchestrator/docker.go
+++ b/control-plane/internal/orchestrator/docker.go
@@ -207,8 +207,9 @@ func (d *DockerOrchestrator) CreateInstance(ctx context.Context, params CreatePa
 	shmSize, _ := units.RAMInBytes("2g")
 
 	containerCfg := &container.Config{
-		Image:  params.ContainerImage,
-		Env:    env,
+		Image:    params.ContainerImage,
+		Hostname: strings.TrimPrefix(params.Name, "bot-"),
+		Env:      env,
 		Labels: map[string]string{"managed-by": labelManagedBy, "instance": params.Name},
 		ExposedPorts: nat.PortSet{
 			"22/tcp": struct{}{},

--- a/control-plane/internal/orchestrator/kubernetes.go
+++ b/control-plane/internal/orchestrator/kubernetes.go
@@ -456,6 +456,7 @@ func buildDeployment(params CreateParams, ns string) *appsv1.Deployment {
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": params.Name, "managed-by": "claworc"}},
 				Spec: corev1.PodSpec{
+					Hostname:   strings.TrimPrefix(params.Name, "bot-"),
 					Containers: []corev1.Container{{
 						Name:            "claworc-instance",
 						Image:           params.ContainerImage,


### PR DESCRIPTION
## Summary
- Remove `navigateFallback` from the service worker config (`navigateFallback: null`) to prevent it from intercepting `/openclaw/` routes that should be handled by the Go server
- Fix WebSocket protocol selection in ActionButtons to use `wss:` on HTTPS connections
- Set container/pod hostname from instance name in both Docker and Kubernetes orchestrators

## Test plan
- [ ] Verify `/openclaw/` navigation works correctly and is not intercepted by the service worker
- [ ] Verify WebSocket connections work on both HTTP and HTTPS
- [ ] Verify container hostname is set correctly in Docker
- [ ] Frontend build passes
- [ ] Go handler tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)