### PR TITLE
fix: update Dockerfile Go version to 1.25

### DIFF
--- a/control-plane/Dockerfile
+++ b/control-plane/Dockerfile
@@ -6,7 +6,7 @@ RUN npm ci
 COPY frontend/ .
 RUN npx vite build
 
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 RUN apk add --no-cache gcc musl-dev
 


### PR DESCRIPTION
## Summary

- Update Dockerfile base image from `golang:1.24-alpine` to `golang:1.25-alpine` to match `go.mod` requirement of Go 1.25.0
- Fixes Docker build failures on main branch after merging #70

## Test plan

- [ ] Docker build succeeds for both amd64 and arm64
- [ ] All existing CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)