### PR TITLE
feat: CLAWORC_BACKUPS_PATH env var for separate backups storage (#92)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,6 +64,7 @@ Axios for API calls. The `@` import alias maps to `src/`.
 
 Backend settings use `envconfig` with `CLAWORC_` env prefix (see `internal/config/config.go`):
 - `CLAWORC_DATA_PATH` - Data directory for SQLite database and SSH keys (default: `/app/data`)
+- `CLAWORC_BACKUPS_PATH` - Directory for backup archives (default: empty, falls back to `<DATA_PATH>/backups`)
 - `CLAWORC_K8S_NAMESPACE` - Target namespace (default: `claworc`)
 - `CLAWORC_TERMINAL_HISTORY_LINES` - Scrollback buffer size in lines (default: `1000`, `0` to disable)
 - `CLAWORC_TERMINAL_RECORDING_DIR` - Directory for audit recordings (default: empty, disabled)

--- a/control-plane/internal/backup/backup.go
+++ b/control-plane/internal/backup/backup.go
@@ -30,7 +30,13 @@ var pathAliases = map[string]string{
 }
 
 // BackupDir returns the root directory for backup archives.
+// When CLAWORC_BACKUPS_PATH is set, it is used verbatim (allowing backups to
+// live on a separate volume or slower disk). Otherwise backups are colocated
+// under CLAWORC_DATA_PATH/backups.
 func BackupDir() string {
+	if config.Cfg.BackupsPath != "" {
+		return config.Cfg.BackupsPath
+	}
 	return filepath.Join(config.Cfg.DataPath, "backups")
 }
 

--- a/control-plane/internal/backup/backup_test.go
+++ b/control-plane/internal/backup/backup_test.go
@@ -80,6 +80,34 @@ func setupTestDataPath(t *testing.T) string {
 	return dir
 }
 
+// --- BackupDir ---
+
+func TestBackupDir_DefaultUnderDataPath(t *testing.T) {
+	origData, origBackups := config.Cfg.DataPath, config.Cfg.BackupsPath
+	t.Cleanup(func() {
+		config.Cfg.DataPath = origData
+		config.Cfg.BackupsPath = origBackups
+	})
+	config.Cfg.DataPath = "/app/data"
+	config.Cfg.BackupsPath = ""
+	if got := BackupDir(); got != "/app/data/backups" {
+		t.Errorf("BackupDir() = %q, want /app/data/backups", got)
+	}
+}
+
+func TestBackupDir_OverrideWithBackupsPath(t *testing.T) {
+	origData, origBackups := config.Cfg.DataPath, config.Cfg.BackupsPath
+	t.Cleanup(func() {
+		config.Cfg.DataPath = origData
+		config.Cfg.BackupsPath = origBackups
+	})
+	config.Cfg.DataPath = "/app/data"
+	config.Cfg.BackupsPath = "/mnt/cold-storage/claworc"
+	if got := BackupDir(); got != "/mnt/cold-storage/claworc" {
+		t.Errorf("BackupDir() = %q, want /mnt/cold-storage/claworc", got)
+	}
+}
+
 // --- ResolvePaths ---
 
 func TestResolvePaths_Empty(t *testing.T) {

--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 
 type Settings struct {
 	DataPath     string   `envconfig:"DATA_PATH" default:"/app/data"`
+	BackupsPath  string   `envconfig:"BACKUPS_PATH" default:""`
 	K8sNamespace string   `envconfig:"K8S_NAMESPACE" default:"claworc"`
 	DockerHost   string   `envconfig:"DOCKER_HOST" default:""`
 	AuthDisabled bool     `envconfig:"AUTH_DISABLED" default:"false"`

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -29,11 +29,19 @@ spec:
           env:
             - name: CLAWORC_DATA_PATH
               value: {{ .Values.config.dataPath | quote }}
+            {{- if .Values.config.backupsPath }}
+            - name: CLAWORC_BACKUPS_PATH
+              value: {{ .Values.config.backupsPath | quote }}
+            {{- end }}
             - name: CLAWORC_K8S_NAMESPACE
               value: {{ .Values.config.k8sNamespace | quote }}
           volumeMounts:
             - name: data
               mountPath: /app/data
+            {{- if and .Values.backupsPersistence.enabled .Values.config.backupsPath }}
+            - name: backups
+              mountPath: {{ .Values.config.backupsPath | quote }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: {{ .Values.probes.liveness.path }}
@@ -58,3 +66,8 @@ spec:
           {{- else }}
           emptyDir: {}
           {{- end }}
+        {{- if and .Values.backupsPersistence.enabled .Values.config.backupsPath }}
+        - name: backups
+          persistentVolumeClaim:
+            claimName: {{ include "claworc.fullname" . }}-backups
+        {{- end }}

--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -16,3 +16,22 @@ spec:
     requests:
       storage: {{ .Values.persistence.size }}
 {{- end }}
+{{- if and .Values.backupsPersistence.enabled .Values.config.backupsPath }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "claworc.fullname" . }}-backups
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "claworc.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.backupsPersistence.accessMode }}
+  {{- if .Values.backupsPersistence.storageClass }}
+  storageClassName: {{ .Values.backupsPersistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.backupsPersistence.size }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,6 +2,11 @@ replicaCount: 1
 
 config:
   dataPath: /app/data
+  # backupsPath: when set, backup archives are stored here instead of under
+  # <dataPath>/backups. Useful for directing backups to cheaper/slower storage.
+  # Set together with backupsPersistence.enabled=true to back this path with a
+  # separate PVC.
+  backupsPath: ""
   k8sNamespace: claworc
 
 service:
@@ -12,6 +17,15 @@ service:
 persistence:
   enabled: true
   size: 1Gi
+  storageClass: ""
+  accessMode: ReadWriteOnce
+
+# Optional separate PVC for backup archives. Requires config.backupsPath to be
+# set to the mount path (e.g. /app/backups). Leave disabled to keep backups on
+# the main data volume.
+backupsPersistence:
+  enabled: false
+  size: 10Gi
   storageClass: ""
   accessMode: ReadWriteOnce
 

--- a/website_docs/backups.mdx
+++ b/website_docs/backups.mdx
@@ -28,6 +28,13 @@ If you don't select any paths, `HOME` is used by default. You can also enter any
 
 System directories such as `/proc`, `/sys`, `/dev`, `/tmp`, and `/run` are always excluded.
 
+## Where backups are stored
+
+By default, backup archives are written under `<CLAWORC_DATA_PATH>/backups` on the
+control plane. To direct backups to a different volume — for example, a larger or
+cheaper disk — set `CLAWORC_BACKUPS_PATH` to the desired directory. See
+[Environment variables](/environment-variables) for details.
+
 ## Creating a manual backup
 
 1. Open **Backups** in the sidebar.

--- a/website_docs/environment-variables.mdx
+++ b/website_docs/environment-variables.mdx
@@ -10,6 +10,7 @@ All Claworc configuration is done via environment variables with the `CLAWORC_` 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `CLAWORC_DATA_PATH` | `/app/data` | Directory to store the Claworc's data like SQLite database, SSH key pair, and etc. Mount a persistent volume here. |
+| `CLAWORC_BACKUPS_PATH` | *(empty)* | Directory for backup archives. When empty, backups are written under `<CLAWORC_DATA_PATH>/backups`. Set this to place backups on a separate (for example, cheaper or slower) volume. The directory must exist and be writable. |
 | `CLAWORC_K8S_NAMESPACE` | `claworc` | Kubernetes namespace where agent instances are created. Must exist before starting. |
 | `CLAWORC_DOCKER_HOST` | *(empty)* | Docker socket or TCP address. Example: `unix:///var/run/docker.sock`. Leave empty to auto-detect orchestrator (Kubernetes takes priority). |
 


### PR DESCRIPTION
## Summary

- Add `CLAWORC_BACKUPS_PATH` env var so backups can live on a dedicated volume/disk, decoupled from the main data directory
- Backend resolves the backup directory through a single `BackupDir()` helper that prefers `BackupsPath` and falls back to `<DataPath>/backups` so all call sites stay consistent
- Helm chart gains optional `backupsPersistence` block that provisions a separate PVC and mounts it at the configured path when enabled
- Docs updated: env var table, new "Where backups are stored" section in the backups page, and project `CLAUDE.md`

Closes #92

## Test plan

- [x] `go build ./internal/config/... ./internal/backup/...`
- [x] `go test ./internal/backup/ ./internal/config/` (new unit tests for default and override behavior)
- [x] `helm template` in three modes: defaults, `backupsPath` only, and `backupsPath` + `backupsPersistence.enabled`