### PR TITLE
feat: per-user task visibility for TaskManager

### DIFF
--- a/control-plane/internal/backup/backup.go
+++ b/control-plane/internal/backup/backup.go
@@ -72,7 +72,7 @@ func ResolvePaths(aliases []string) []string {
 
 // CreateFullBackup creates a full backup of the specified paths in the given instance.
 // It runs asynchronously — the backup is created in a goroutine.
-func CreateFullBackup(ctx context.Context, orch orchestrator.ContainerOrchestrator, instanceName string, instanceID uint, note string, paths []string) (uint, error) {
+func CreateFullBackup(ctx context.Context, orch orchestrator.ContainerOrchestrator, instanceName string, instanceID, userID uint, note string, paths []string) (uint, error) {
 	now := time.Now().UTC()
 	dir := filepath.Join(BackupDir(), instanceName)
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -105,6 +105,7 @@ func CreateFullBackup(ctx context.Context, orch orchestrator.ContainerOrchestrat
 		TaskMgr.Start(taskmanager.StartOpts{
 			Type:         taskmanager.TaskBackupCreate,
 			InstanceID:   instanceID,
+			UserID:       userID,
 			ResourceID:   strconv.FormatUint(uint64(b.ID), 10),
 			ResourceName: fmt.Sprintf("%s backup", instanceName),
 			OnCancel:     backupOnCancel(b.ID, absPath),

--- a/control-plane/internal/backup/backup_test.go
+++ b/control-plane/internal/backup/backup_test.go
@@ -234,7 +234,7 @@ func TestCreateFullBackup_Success(t *testing.T) {
 	inst := database.Instance{Name: "test-inst", DisplayName: "Test", Status: "running"}
 	database.DB.Create(&inst)
 
-	backupID, err := CreateFullBackup(context.Background(), orch, inst.Name, inst.ID, "test note", []string{"HOME"})
+	backupID, err := CreateFullBackup(context.Background(), orch, inst.Name, inst.ID, 0, "test note", []string{"HOME"})
 	if err != nil {
 		t.Fatalf("CreateFullBackup failed: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestCreateFullBackup_StreamError(t *testing.T) {
 	inst := database.Instance{Name: "test-err", DisplayName: "Test", Status: "running"}
 	database.DB.Create(&inst)
 
-	backupID, err := CreateFullBackup(context.Background(), orch, inst.Name, inst.ID, "", nil)
+	backupID, err := CreateFullBackup(context.Background(), orch, inst.Name, inst.ID, 0, "", nil)
 	if err != nil {
 		t.Fatalf("CreateFullBackup should not fail synchronously: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestCreateFullBackup_TarExitCode2(t *testing.T) {
 	inst := database.Instance{Name: "test-tar2", DisplayName: "Test", Status: "running"}
 	database.DB.Create(&inst)
 
-	backupID, _ := CreateFullBackup(context.Background(), orch, inst.Name, inst.ID, "", nil)
+	backupID, _ := CreateFullBackup(context.Background(), orch, inst.Name, inst.ID, 0, "", nil)
 
 	deadline := time.Now().Add(5 * time.Second)
 	for {
@@ -378,7 +378,7 @@ func TestCreateFullBackup_TarExitCode1_Accepted(t *testing.T) {
 	inst := database.Instance{Name: "test-tar1", DisplayName: "Test", Status: "running"}
 	database.DB.Create(&inst)
 
-	backupID, _ := CreateFullBackup(context.Background(), orch, inst.Name, inst.ID, "", nil)
+	backupID, _ := CreateFullBackup(context.Background(), orch, inst.Name, inst.ID, 0, "", nil)
 
 	deadline := time.Now().Add(5 * time.Second)
 	for {
@@ -414,7 +414,7 @@ func TestCreateFullBackup_DefaultPaths(t *testing.T) {
 	inst := database.Instance{Name: "test-default", DisplayName: "Test", Status: "running"}
 	database.DB.Create(&inst)
 
-	CreateFullBackup(context.Background(), orch, inst.Name, inst.ID, "", nil)
+	CreateFullBackup(context.Background(), orch, inst.Name, inst.ID, 0, "", nil)
 
 	// Wait for goroutine to start and capture the command
 	deadline := time.Now().Add(5 * time.Second)

--- a/control-plane/internal/backup/scheduler.go
+++ b/control-plane/internal/backup/scheduler.go
@@ -79,7 +79,7 @@ func executeSchedule(ctx context.Context, orch orchestrator.ContainerOrchestrato
 			log.Printf("backup scheduler: schedule %d: instance %d not found: %v", s.ID, instID, err)
 			continue
 		}
-		if _, err := CreateFullBackup(ctx, orch, inst.Name, inst.ID, "scheduled", paths); err != nil {
+		if _, err := CreateFullBackup(ctx, orch, inst.Name, inst.ID, 0, "scheduled", paths); err != nil {
 			log.Printf("backup scheduler: schedule %d: backup for instance %s failed: %v", s.ID, inst.Name, err)
 		}
 	}

--- a/control-plane/internal/handlers/backups.go
+++ b/control-plane/internal/handlers/backups.go
@@ -53,7 +53,7 @@ func CreateBackup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	backupID, err := backup.CreateFullBackup(r.Context(), orch, inst.Name, inst.ID, req.Note, req.Paths)
+	backupID, err := backup.CreateFullBackup(r.Context(), orch, inst.Name, inst.ID, callerID(r), req.Note, req.Paths)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to start backup: %v", err))
 		return

--- a/control-plane/internal/handlers/instances.go
+++ b/control-plane/internal/handlers/instances.go
@@ -34,7 +34,7 @@ import (
 // The goroutine bodies still update the instance DB row themselves; the
 // task return value is informational for toast UX. We infer "failed" from
 // the in-memory status message ("Failed: ...") so the toast turns red.
-func startInstanceTask(taskType taskmanager.TaskType, instanceID uint, displayName string, work func(ctx context.Context)) {
+func startInstanceTask(taskType taskmanager.TaskType, instanceID, userID uint, displayName string, work func(ctx context.Context)) {
 	if TaskMgr == nil {
 		go work(context.Background())
 		return
@@ -42,6 +42,7 @@ func startInstanceTask(taskType taskmanager.TaskType, instanceID uint, displayNa
 	TaskMgr.Start(taskmanager.StartOpts{
 		Type:         taskType,
 		InstanceID:   instanceID,
+		UserID:       userID,
 		ResourceName: displayName,
 		Run: func(ctx context.Context, h *taskmanager.Handle) error {
 			work(ctx)
@@ -51,6 +52,15 @@ func startInstanceTask(taskType taskmanager.TaskType, instanceID uint, displayNa
 			return nil
 		},
 	})
+}
+
+// callerID returns the authenticated caller's user ID, or 0 if no user is
+// in context. Used to stamp UserID onto tasks for visibility filtering.
+func callerID(r *http.Request) uint {
+	if u := middleware.GetUser(r); u != nil {
+		return u.ID
+	}
+	return 0
 }
 
 // In-memory status messages for instance creation progress.
@@ -505,7 +515,7 @@ func getEffectiveUserAgent(inst database.Instance) string {
 // restartInstanceAsync restarts a running instance in the background,
 // rebuilding its container with current config and shared folder mounts.
 // Safe to call for stopped instances (no-op if status is not "running").
-func restartInstanceAsync(inst database.Instance) {
+func restartInstanceAsync(inst database.Instance, userID uint) {
 	if inst.Status != "running" {
 		return
 	}
@@ -529,7 +539,7 @@ func restartInstanceAsync(inst database.Instance) {
 		"updated_at": time.Now().UTC(),
 	})
 
-	startInstanceTask(taskmanager.TaskInstanceRestart, inst.ID, inst.DisplayName, func(ctx context.Context) {
+	startInstanceTask(taskmanager.TaskInstanceRestart, inst.ID, userID, inst.DisplayName, func(ctx context.Context) {
 		params := buildCreateParams(inst)
 		if err := orch.RestartInstance(ctx, inst.Name, params); err != nil {
 			log.Printf("Failed to restart instance %d: %v", inst.ID, err)
@@ -806,7 +816,7 @@ func CreateInstance(w http.ResponseWriter, r *http.Request) {
 	initialProvidersJSON, _ := buildOpenClawProvidersJSON(models, gatewayProviders, config.Cfg.LLMGatewayPort)
 
 	// Launch container creation asynchronously (image pull can take minutes)
-	startInstanceTask(taskmanager.TaskInstanceCreate, inst.ID, inst.DisplayName, func(ctx context.Context) {
+	startInstanceTask(taskmanager.TaskInstanceCreate, inst.ID, callerID(r), inst.DisplayName, func(ctx context.Context) {
 		orch := orchestrator.Get()
 		if orch == nil {
 			setStatusMessage(inst.ID, "Failed: no orchestrator available")
@@ -1200,7 +1210,7 @@ func UpdateInstance(w http.ResponseWriter, r *http.Request) {
 	// re-reads EnvVars from the DB, so it picks up what we just wrote.
 	restarting := false
 	if envVarsChanged && status == "running" {
-		restartInstanceAsync(inst)
+		restartInstanceAsync(inst, callerID(r))
 		restarting = true
 		status = "restarting"
 	}
@@ -1328,7 +1338,7 @@ func UpdateInstanceImage(w http.ResponseWriter, r *http.Request) {
 
 	instID := inst.ID
 	instName := inst.Name
-	startInstanceTask(taskmanager.TaskInstanceImageUpdate, inst.ID, inst.DisplayName, func(ctx context.Context) {
+	startInstanceTask(taskmanager.TaskInstanceImageUpdate, inst.ID, callerID(r), inst.DisplayName, func(ctx context.Context) {
 		err := orch.UpdateImage(ctx, instName, orchestrator.CreateParams{
 			Name:               instName,
 			CPURequest:         inst.CPURequest,
@@ -1704,7 +1714,7 @@ func CloneInstance(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Run the full clone operation asynchronously
-	startInstanceTask(taskmanager.TaskInstanceClone, inst.ID, inst.DisplayName, func(ctx context.Context) {
+	startInstanceTask(taskmanager.TaskInstanceClone, inst.ID, callerID(r), inst.DisplayName, func(ctx context.Context) {
 		orch := orchestrator.Get()
 		if orch == nil {
 			setStatusMessage(inst.ID, "Failed: no orchestrator available")

--- a/control-plane/internal/handlers/settings.go
+++ b/control-plane/internal/handlers/settings.go
@@ -167,7 +167,7 @@ func UpdateSettings(w http.ResponseWriter, r *http.Request) {
 		var running []database.Instance
 		database.DB.Where("status = ?", "running").Find(&running)
 		for i := range running {
-			restartInstanceAsync(running[i])
+			restartInstanceAsync(running[i], callerID(r))
 			restartingInstances = append(restartingInstances, restartTarget{
 				ID:          running[i].ID,
 				Name:        running[i].Name,

--- a/control-plane/internal/handlers/shared_folders.go
+++ b/control-plane/internal/handlers/shared_folders.go
@@ -265,7 +265,7 @@ func UpdateSharedFolder(w http.ResponseWriter, r *http.Request) {
 			if err := database.DB.First(&inst, instID).Error; err != nil {
 				continue
 			}
-			restartInstanceAsync(inst)
+			restartInstanceAsync(inst, callerID(r))
 		}
 	}
 
@@ -326,7 +326,7 @@ func DeleteSharedFolder(w http.ResponseWriter, r *http.Request) {
 		if err := database.DB.First(&inst, instID).Error; err != nil {
 			continue
 		}
-		restartInstanceAsync(inst)
+		restartInstanceAsync(inst, callerID(r))
 	}
 
 	// Delete the backing volume in the background (after instances have unmounted it)

--- a/control-plane/internal/handlers/skills.go
+++ b/control-plane/internal/handlers/skills.go
@@ -501,6 +501,7 @@ func DeploySkill(w http.ResponseWriter, r *http.Request) {
 		taskID := TaskMgr.Start(taskmanager.StartOpts{
 			Type:         taskmanager.TaskSkillDeploy,
 			InstanceID:   instanceID,
+			UserID:       callerID(r),
 			ResourceID:   slug,
 			ResourceName: displayName,
 			Run: func(ctx context.Context, h *taskmanager.Handle) error {

--- a/control-plane/internal/handlers/tasks.go
+++ b/control-plane/internal/handlers/tasks.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/gluk-w/claworc/control-plane/internal/database"
 	"github.com/gluk-w/claworc/control-plane/internal/middleware"
 	"github.com/gluk-w/claworc/control-plane/internal/taskmanager"
 	"github.com/go-chi/chi/v5"
@@ -15,11 +14,11 @@ import (
 // TaskMgr is the global task manager, wired from main.go.
 var TaskMgr *taskmanager.Manager
 
-// rbacFilter returns a predicate that decides whether a task is visible to
-// the caller. Admins see everything; non-admins see tasks whose InstanceID
-// is in the caller's assigned instance set. Tasks with InstanceID == 0
-// are admin-only.
-func rbacFilter(r *http.Request) (func(taskmanager.Task) bool, error) {
+// visibilityFilter returns a predicate that decides whether a task is
+// visible to the caller. Admins see everything; non-admins see only tasks
+// they themselves initiated (Task.UserID == caller.ID). Tasks with
+// UserID == 0 are system-initiated and admin-only.
+func visibilityFilter(r *http.Request) (func(taskmanager.Task) bool, error) {
 	user := middleware.GetUser(r)
 	if user == nil {
 		return nil, errors.New("no user")
@@ -27,20 +26,9 @@ func rbacFilter(r *http.Request) (func(taskmanager.Task) bool, error) {
 	if user.Role == "admin" {
 		return func(taskmanager.Task) bool { return true }, nil
 	}
-	ids, err := database.GetUserInstances(user.ID)
-	if err != nil {
-		return nil, err
-	}
-	allow := make(map[uint]struct{}, len(ids))
-	for _, id := range ids {
-		allow[id] = struct{}{}
-	}
+	uid := user.ID
 	return func(t taskmanager.Task) bool {
-		if t.InstanceID == 0 {
-			return false
-		}
-		_, ok := allow[t.InstanceID]
-		return ok
+		return t.UserID != 0 && t.UserID == uid
 	}, nil
 }
 
@@ -51,7 +39,7 @@ func ListTasks(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, []taskmanager.Task{})
 		return
 	}
-	allow, err := rbacFilter(r)
+	allow, err := visibilityFilter(r)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -90,7 +78,7 @@ func GetTask(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "Task not found")
 		return
 	}
-	allow, err := rbacFilter(r)
+	allow, err := visibilityFilter(r)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -114,7 +102,7 @@ func CancelTask(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusNotFound, "Task not found")
 		return
 	}
-	allow, err := rbacFilter(r)
+	allow, err := visibilityFilter(r)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return
@@ -148,7 +136,7 @@ func StreamTaskEvents(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "Task manager not initialized")
 		return
 	}
-	allow, err := rbacFilter(r)
+	allow, err := visibilityFilter(r)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/control-plane/internal/taskmanager/taskmanager.go
+++ b/control-plane/internal/taskmanager/taskmanager.go
@@ -57,7 +57,8 @@ type RunFunc func(ctx context.Context, h *Handle) error
 type Task struct {
 	ID           string     `json:"id"`
 	Type         TaskType   `json:"type"`
-	InstanceID   uint       `json:"instance_id,omitempty"` // RBAC anchor; 0 = admin-only
+	InstanceID   uint       `json:"instance_id,omitempty"` // metadata only — used for filtering and toast subject
+	UserID       uint       `json:"user_id,omitempty"`     // visibility anchor; 0 = system task (admin-only)
 	ResourceID   string     `json:"resource_id,omitempty"` // type-specific (backup id, etc.)
 	ResourceName string     `json:"resource_name,omitempty"`
 	State        State      `json:"state"`
@@ -70,6 +71,7 @@ type Task struct {
 type StartOpts struct {
 	Type         TaskType
 	InstanceID   uint
+	UserID       uint // initiating user; 0 = system task (admin-only visibility)
 	ResourceID   string
 	ResourceName string
 	OnCancel     OnCancel
@@ -114,6 +116,7 @@ type Event struct {
 type Filter struct {
 	Type       TaskType
 	InstanceID uint // 0 = any
+	UserID     uint // 0 = any
 	ResourceID string
 	State      State
 	OnlyActive bool // if true, exclude tasks that ended more than `since` ago
@@ -209,6 +212,7 @@ func (m *Manager) Start(opts StartOpts) string {
 			ID:           id,
 			Type:         opts.Type,
 			InstanceID:   opts.InstanceID,
+			UserID:       opts.UserID,
 			ResourceID:   opts.ResourceID,
 			ResourceName: opts.ResourceName,
 			State:        StateRunning,
@@ -263,6 +267,9 @@ func (m *Manager) List(f Filter) []Task {
 			continue
 		}
 		if f.InstanceID != 0 && t.InstanceID != f.InstanceID {
+			continue
+		}
+		if f.UserID != 0 && t.UserID != f.UserID {
 			continue
 		}
 		if f.ResourceID != "" && t.ResourceID != f.ResourceID {

--- a/control-plane/internal/taskmanager/taskmanager_test.go
+++ b/control-plane/internal/taskmanager/taskmanager_test.go
@@ -192,6 +192,37 @@ func TestListFilters(t *testing.T) {
 	_ = m.Cancel(idA)
 }
 
+func TestUserIDFilterAndStamping(t *testing.T) {
+	m := newTestManager(t)
+	idAlice := m.Start(StartOpts{Type: TaskInstanceCreate, InstanceID: 1, UserID: 7,
+		Run: func(ctx context.Context, h *Handle) error { return nil }})
+	idBob := m.Start(StartOpts{Type: TaskInstanceCreate, InstanceID: 1, UserID: 9,
+		Run: func(ctx context.Context, h *Handle) error { return nil }})
+	idSystem := m.Start(StartOpts{Type: TaskBackupCreate, InstanceID: 1,
+		Run: func(ctx context.Context, h *Handle) error { return nil }})
+
+	for _, id := range []string{idAlice, idBob, idSystem} {
+		waitFor(t, func() bool {
+			tk, _ := m.Get(id)
+			return tk.State == StateSucceeded
+		}, time.Second, "task finished")
+	}
+
+	alice, _ := m.Get(idAlice)
+	if alice.UserID != 7 {
+		t.Fatalf("UserID not stamped on Task: got %d, want 7", alice.UserID)
+	}
+	system, _ := m.Get(idSystem)
+	if system.UserID != 0 {
+		t.Fatalf("system task UserID should be 0, got %d", system.UserID)
+	}
+
+	mine := m.List(Filter{UserID: 7})
+	if len(mine) != 1 || mine[0].ID != idAlice {
+		t.Fatalf("UserID filter wrong: %+v", mine)
+	}
+}
+
 func TestSubscriberBackpressureDoesNotBlock(t *testing.T) {
 	m := newTestManager(t)
 	// Subscriber that never reads — its channel will fill and events drop.

--- a/docs/task-manager.md
+++ b/docs/task-manager.md
@@ -29,10 +29,15 @@ historical record while the live in-memory `Task` is authoritative.
   sessions. **A nil `OnCancel` means the task is not user-cancellable**:
   `Manager.Cancel` returns `ErrNotCancellable` and the REST handler maps
   that to **405 Method Not Allowed**.
-- **`InstanceID`** on a Task is the canonical RBAC anchor. Tasks with
-  `InstanceID == 0` are admin-only; all current task types carry an
-  instance ID (for `backup.create` we resolve `Backup.InstanceID` at task
-  creation time).
+- **`InstanceID`** on a Task is metadata used for filtering
+  (`?instance_id=`) and the toast subject line. It is **not** the access
+  predicate.
+- **`UserID`** on a Task is the visibility anchor — the ID of the user
+  who initiated the work. Non-admins only see tasks where
+  `Task.UserID == caller.ID`. `UserID == 0` denotes a system-initiated
+  task (e.g. scheduled backup) and is admin-only. Always pass
+  `callerID(r)` from the HTTP handler so toasts surface to the user who
+  clicked the button — not to everyone with access to the same instance.
 
 ## Usage from a handler
 
@@ -48,6 +53,7 @@ import (
 handlers.TaskMgr.Start(taskmanager.StartOpts{
     Type:         taskmanager.TaskBackupCreate,
     InstanceID:   inst.ID,
+    UserID:       callerID(r), // visibility — toast goes only to this user
     ResourceID:   strconv.FormatUint(uint64(b.ID), 10),
     ResourceName: fmt.Sprintf("%s backup", inst.Name),
     OnCancel:     backupOnCancel(b.ID, absPath), // nil = not cancellable
@@ -97,19 +103,20 @@ All endpoints are mounted under `/api/v1/tasks` and require auth.
 | `POST` | `/api/v1/tasks/{id}/cancel` | Cancel; 405 if not cancellable, 409 if already terminal |
 | `GET` | `/api/v1/tasks/events` | SSE stream of `{type, task}` JSON |
 
-### RBAC
+### Visibility
 
-Mirrors the existing instance access model exactly (no new auth concepts):
+Tasks belong to the user who started them. A toast for "Restarting bot-foo"
+should surface to the user who clicked Restart — not to every other user
+who happens to have access to that instance.
 
-- Admin (`User.Role == "admin"`): sees and acts on every task.
-- Non-admin: sees only tasks whose `InstanceID` is in
-  `database.GetUserInstances(user.ID)`. `InstanceID == 0` tasks are
-  admin-only.
-- The same predicate gates `GET /tasks/{id}`, `POST /tasks/{id}/cancel`,
-  and the per-event filter on `/tasks/events`. Each SSE subscriber
-  captures `(isAdmin, allowedInstanceIDs)` at connect time; instance
-  assignment changes require a reconnect to take effect (matches the
-  polling cadence of `GET /instances`).
+- Admin (`User.Role == "admin"`): sees and acts on every task, including
+  system-initiated tasks (`UserID == 0`).
+- Non-admin: sees only tasks where `Task.UserID == User.ID`. Tasks with
+  `UserID == 0` are admin-only.
+- The same predicate gates `GET /tasks`, `GET /tasks/{id}`,
+  `POST /tasks/{id}/cancel`, and the per-event filter on `/tasks/events`.
+  Each SSE subscriber captures `(isAdmin, userID)` at connect time;
+  changing roles requires a reconnect to take effect.
 
 ### SSE event shape
 
@@ -144,8 +151,10 @@ rows as history and let the user retry.
    `backup.TaskMgr.Start` if you're inside the `backup` package).
 3. Decide cancellability: provide an `OnCancel` (cleanup) or leave it nil
    (not user-cancellable, returns 405).
-4. Set `InstanceID` for RBAC. Use 0 only for system-level tasks that
-   should be admin-only.
+4. Set `UserID` from the request (`callerID(r)`) so the toast surfaces
+   only to the user who triggered the action. Use 0 only for
+   system-initiated work (e.g. cron / scheduler), which is admin-only.
+   Set `InstanceID` for filtering and toast labels.
 5. On the frontend, add a label in `TaskToasts.tsx` (`TYPE_LABEL` map) so
    the toast says something humans recognise.
 6. If you added a new failure mode that can leave a DB row stuck, extend


### PR DESCRIPTION
## Summary

Replace the prior instance-set RBAC for TaskManager with a per-user visibility model so background-task toasts surface only to the user who initiated the action.

- Tasks are stamped with the initiating user's ID at start; non-admin users only see their own tasks via the tasks API.
- System-initiated tasks (e.g. scheduled backups) carry `UserID = 0` and are admin-only.
- Removes the dependency on `database.GetUserInstances` from the tasks handler.

## Breaking-ish change

`backup.CreateFullBackup` now takes a `userID uint` argument (pass `0` for system contexts). All in-tree callers updated; external callers will need to pass a user ID.

## Notes

- No frontend changes required.
- New unit test: `TestUserIDFilterAndStamping` in `internal/taskmanager`.
- Docs updated: `docs/task-manager.md` (Concepts, Visibility section, StartOpts example, "adding a new task type" checklist).

## Test plan

- [ ] CI: `go build ./...` and `go test ./...` pass
- [ ] CI: frontend build and Docker image push succeed
- [ ] Manual: non-admin user sees only their own task toasts; admin sees all including system-initiated