### PR TITLE
docs: sync user management for unified create/edit modal

### DIFF
--- a/website_docs/authentication.mdx
+++ b/website_docs/authentication.mdx
@@ -59,12 +59,17 @@ Admins manage users from **Settings** → **Users**:
 
 | Action | How |
 |--------|-----|
-| Create user | Click **Add user**, enter username and password |
-| Change role | Edit user → change Role dropdown |
-| Toggle Can-create-instances | Tick or untick the **Can create instances** checkbox in the user row |
-| Assign instances | Edit user → select instances from the list |
-| Reset password | Edit user → click **Reset password** |
-| Delete user | Edit user → click **Delete** |
+| Create user | Click **Add user**, enter username and password, choose role and assigned instances, then save |
+| Edit user | Click the username in the table to open the edit dialog |
+| Change role | Open the user → change the **Role** dropdown. Selecting **Admin** automatically grants access to all instances |
+| Toggle Can-create-instances | Open the user → tick or untick **Can create instances** |
+| Assign instances | Open the user → pick instances from the list (disabled for admins, who always have access to all instances) |
+| Reset password | Open the user → click **Reset password** |
+| Delete user | Open the user → click **Delete** and confirm |
+
+<Tip>
+Press **Enter** to save changes in the user dialog, or **Escape** to cancel.
+</Tip>
 
 ---
 


### PR DESCRIPTION
## Summary

Updates the **User management** section of `authentication.mdx` to reflect the new Users page UX (PR #103):

- Click-username-to-edit instead of a separate edit icon
- Unified create/edit dialog covers role, can-create, and assigned instances
- Note that selecting **Admin** auto-grants access to all instances
- Mention the Enter/Escape keyboard shortcuts in the dialog