### PR TITLE
fix(website): restore analytics collector endpoint accidentally removed in #108

### DIFF
--- a/website/worker/index.test.ts
+++ b/website/worker/index.test.ts
@@ -68,7 +68,7 @@ vi.mock("./models.json", () => ({
 import worker from "./index";
 
 async function get(path: string): Promise<Response> {
-  return worker.fetch(new Request(`https://example.com${path}`));
+  return worker.fetch(new Request(`https://example.com${path}`), {} as any, {} as any);
 }
 
 describe("Provider list", () => {
@@ -126,6 +126,83 @@ describe("Provider list", () => {
     expect(m.cached_write_cost).toBeNull();
     expect(m.tag).toBe("flagship");
     expect(m.description).toBe("Most capable model");
+  });
+});
+
+describe("Analytics collect", () => {
+  function makeEnv() {
+    const points: any[] = [];
+    return {
+      env: {
+        ANALYTICS: {
+          writeDataPoint: (p: any) => points.push(p),
+        },
+      },
+      points,
+    };
+  }
+
+  async function post(path: string, body: unknown, env: any = {}) {
+    return worker.fetch(
+      new Request(`https://example.com${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: typeof body === "string" ? body : JSON.stringify(body),
+      }),
+      env,
+      {} as any,
+    );
+  }
+
+  const validPayload = {
+    installation_id: "a".repeat(32),
+    event: "instance_created",
+    props: { total_instances: 3 },
+    ts: 1700000000,
+    version: "1.2.3",
+  };
+
+  it("accepts a well-formed payload and writes one data point", async () => {
+    const { env, points } = makeEnv();
+    const res = await post("/stats/collect", validPayload, env);
+    expect(res.status).toBe(204);
+    expect(points.length).toBe(1);
+    expect(points[0].indexes).toEqual([validPayload.installation_id]);
+    expect(points[0].blobs?.[0]).toBe("instance_created");
+  });
+
+  it("rejects unknown events", async () => {
+    const { env, points } = makeEnv();
+    const res = await post("/stats/collect", { ...validPayload, event: "bogus_event" }, env);
+    expect(res.status).toBe(400);
+    expect(points.length).toBe(0);
+  });
+
+  it("rejects malformed installation_id", async () => {
+    const { env } = makeEnv();
+    const res = await post("/stats/collect", { ...validPayload, installation_id: "short" }, env);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects malformed JSON", async () => {
+    const { env } = makeEnv();
+    const res = await post("/stats/collect", "{not-json", env);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects GET", async () => {
+    const res = await worker.fetch(new Request("https://example.com/stats/collect"), {} as any, {} as any);
+    expect(res.status).toBe(405);
+  });
+
+  it("answers OPTIONS preflight", async () => {
+    const res = await worker.fetch(
+      new Request("https://example.com/stats/collect", { method: "OPTIONS" }),
+      {} as any,
+      {} as any,
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("*");
   });
 });
 

--- a/website/worker/index.ts
+++ b/website/worker/index.ts
@@ -31,13 +31,116 @@ interface Provider {
 const providers = providersJson as Provider[];
 
 // ---------------------------------------------------------------------------
+// Analytics
+// ---------------------------------------------------------------------------
+
+// Allowlist mirrors control-plane/internal/analytics/events.go. Unknown event
+// names are rejected so a misbehaving or compromised installation can't spray
+// arbitrary strings at our analytics dataset.
+const ALLOWED_EVENTS = new Set([
+  "instance_created",
+  "instance_deleted",
+  "skill_uploaded",
+  "skill_deleted",
+  "shared_folder_created",
+  "shared_folder_deleted",
+  "backup_schedule_created",
+  "backup_created_manual",
+  "user_created",
+  "user_updated",
+  "user_deleted",
+  "password_changed",
+  "provider_added",
+  "provider_deleted",
+  "ssh_key_rotated",
+  "global_env_vars_edited",
+  "instance_env_vars_edited",
+  "opt_out",
+]);
+
+const INSTALLATION_ID_RE = /^[a-f0-9]{32}$/;
+
+interface AnalyticsPayload {
+  installation_id: string;
+  event: string;
+  props?: Record<string, unknown>;
+  ts: number;
+  version: string;
+}
+
+interface Env {
+  ANALYTICS?: {
+    writeDataPoint(point: {
+      blobs?: string[];
+      doubles?: number[];
+      indexes?: string[];
+    }): void;
+  };
+}
+
+function corsHeaders(): HeadersInit {
+  // Customer deployments live on arbitrary infra, so the collector accepts
+  // any origin. The endpoint never returns sensitive data.
+  return {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type",
+  };
+}
+
+async function handleStatsCollect(request: Request, env: Env): Promise<Response> {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: corsHeaders() });
+  }
+  if (request.method !== "POST") {
+    return new Response("Method not allowed", { status: 405, headers: corsHeaders() });
+  }
+
+  let body: AnalyticsPayload;
+  try {
+    body = (await request.json()) as AnalyticsPayload;
+  } catch {
+    return jsonResponse({ error: "Invalid JSON" }, 400);
+  }
+
+  if (!body || typeof body !== "object") {
+    return jsonResponse({ error: "Invalid payload" }, 400);
+  }
+  if (typeof body.installation_id !== "string" || !INSTALLATION_ID_RE.test(body.installation_id)) {
+    return jsonResponse({ error: "Invalid installation_id" }, 400);
+  }
+  if (typeof body.event !== "string" || !ALLOWED_EVENTS.has(body.event)) {
+    return jsonResponse({ error: "Unknown event" }, 400);
+  }
+  if (typeof body.ts !== "number") {
+    return jsonResponse({ error: "Invalid ts" }, 400);
+  }
+  if (typeof body.version !== "string") {
+    return jsonResponse({ error: "Invalid version" }, 400);
+  }
+
+  // Serialize props to a single blob — Analytics Engine doesn't take maps.
+  const propsBlob = body.props ? JSON.stringify(body.props) : "";
+
+  if (env.ANALYTICS) {
+    env.ANALYTICS.writeDataPoint({
+      blobs: [body.event, body.version, propsBlob],
+      doubles: [body.ts],
+      indexes: [body.installation_id],
+    });
+  }
+
+  return new Response(null, { status: 204, headers: corsHeaders() });
+}
+
+// ---------------------------------------------------------------------------
 // Response helpers
 // ---------------------------------------------------------------------------
 
 function jsonResponse(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...corsHeaders() },
   });
 }
 
@@ -54,13 +157,17 @@ function handleProviderList(): Response {
 // ---------------------------------------------------------------------------
 
 export default {
-  async fetch(request: Request): Promise<Response> {
+  async fetch(request: Request, env: Env): Promise<Response> {
     const { pathname } = new URL(request.url);
 
     if (pathname === "/providers/" || pathname === "/providers") {
       return handleProviderList();
     }
 
+    if (pathname === "/stats/collect") {
+      return handleStatsCollect(request, env);
+    }
+
     return jsonResponse({ error: "Not found" }, 404);
   },
-} satisfies ExportedHandler;
+} satisfies ExportedHandler<Env>;

--- a/website/worker/wrangler.toml
+++ b/website/worker/wrangler.toml
@@ -8,3 +8,11 @@ command = "node build-models.mjs"
 [[routes]]
 pattern = "claworc.com/providers/*"
 zone_name = "claworc.com"
+
+[[routes]]
+pattern = "claworc.com/stats/*"
+zone_name = "claworc.com"
+
+[[analytics_engine_datasets]]
+binding = "ANALYTICS"
+dataset = "claworc_events"


### PR DESCRIPTION
## Summary

PR #108 (static-site restore) inadvertently rolled back `website/worker/` past PR #105's analytics endpoint. The first attempt at this fix (PR #109) merged as a no-op due to the squash diff resolving against an older base — this PR is a fresh branch cut from current `main` so the changes actually land.

This re-adds just the worker pieces from #105:

- `/stats/collect` route handler with CORS support
- Allowed-events allowlist and `installation_id` validation
- `claworc.com/stats/*` route in `wrangler.toml`
- `[[analytics_engine_datasets]]` binding (`ANALYTICS` → `claworc_events`)
- 6 new tests covering the endpoint (15 total tests pass locally)

No other worker behavior is changed.