### PR TITLE
fix(helm): grant update verb on deployments + migration docs

### DIFF
--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["create", "get", "list", "patch", "delete"]
+    verbs: ["create", "get", "list", "patch", "update", "delete"]
   - apiGroups: [""]
     resources: ["services"]
     verbs: ["create", "get", "list", "delete"]

--- a/website_docs/accessing.mdx
+++ b/website_docs/accessing.mdx
@@ -28,11 +28,7 @@ overridden per OpenClaw instance. See [Managing instances](/instances#creating-a
 per-instance fields.
 
 <Note>
-  **Migrating older instances.** OpenClaw instances created before on-demand Chrome sessions were
-  introduced still run the browser inside the agent container. Their detail page shows a banner that
-  lets you switch to on-demand Chrome with one click. The migration preserves your Chrome profile
-  (sign-ins, cookies, extensions) and is one-way — you cannot revert an instance to the embedded
-  browser layout afterwards.
+  **Migrating older instances.** OpenClaw instances created before on-demand Chrome sessions were introduced still run the browser inside the agent container. Their detail page shows a one-click migration banner. See [Migrating to on-demand browser](/migrating-on-demand-browser) for prerequisites and troubleshooting.
 </Note>
 
 ## Terminal

--- a/website_docs/docs.json
+++ b/website_docs/docs.json
@@ -25,6 +25,7 @@
             "group": "Instances",
             "pages": [
               "instances",
+              "migrating-on-demand-browser",
               "accessing",
               "skills",
               "backups",

--- a/website_docs/instances.mdx
+++ b/website_docs/instances.mdx
@@ -31,7 +31,7 @@ All images except `glukw/claworc-browser-chrome` support **AMD64** and **ARM64**
 [Homebrew](https://brew.sh/) is preinstalled in the agent image, so you can install additional packages inside any instance using `brew install` without extra setup.
 
 <Note>
-  **Legacy images.** Earlier instances ran the browser inside the agent container using `glukw/openclaw-vnc-chrome`, `glukw/openclaw-vnc-chromium`, or `glukw/openclaw-vnc-brave`. These images remain published and continue to work for instances created before the agent / browser split. New instances use the pair above. To switch an existing instance, use the migration banner described in [Accessing instances](/accessing#on-demand-chrome-sessions).
+  **Legacy images.** Earlier instances ran the browser inside the agent container using `glukw/openclaw-vnc-chrome`, `glukw/openclaw-vnc-chromium`, or `glukw/openclaw-vnc-brave`. These images remain published and continue to work for instances created before the agent / browser split. New instances use the pair above. To switch an existing instance, see [Migrating to on-demand browser](/migrating-on-demand-browser).
 </Note>
 
 ### Updating the agent and browser images

--- a/website_docs/migrating-on-demand-browser.mdx
+++ b/website_docs/migrating-on-demand-browser.mdx
@@ -1,0 +1,97 @@
+---
+title: "Migrating to on-demand browser"
+description: "Switch existing OpenClaw instances from the legacy combined image to the on-demand agent + browser layout"
+---
+
+OpenClaw instances created before on-demand Chrome sessions were introduced run the agent and browser together inside one `glukw/openclaw-vnc-*` container. New instances use a slim agent image plus a separate browser pod that starts on first use and stops when idle.
+
+This page walks an admin through migrating an existing instance to the on-demand layout.
+
+## What changes
+
+- The agent runs `glukw/claworc-agent` continuously; the browser runs as its own pod from `glukw/claworc-browser-*` and is provisioned on demand.
+- The Chrome profile (sign-ins, cookies, extensions) is preserved.
+- The migration is **one-way** — you cannot revert to the embedded browser layout afterwards.
+
+For the full image catalog, see [Managing instances](/instances#images).
+
+## Before you start
+
+You must be an **admin** to run the migration. Confirm the following first:
+
+| Prerequisite | Where to set it |
+|--------------|-----------------|
+| `default_agent_image` is set | Admin **Settings**. Default `glukw/claworc-agent:latest`. |
+| Agent image is reachable from the cluster or Docker host | Your registry |
+| `default_browser_image` (optional) | Admin **Settings**. Used when an instance has no browser image set. |
+| `default_browser_provider` (optional) | Admin **Settings**. `kubernetes`, `docker`, or `auto`. |
+| `default_browser_storage` (optional) | Admin **Settings**. PVC size for the browser volume (e.g. `10Gi`). |
+
+<Note>
+  **Kubernetes only.** The control plane ServiceAccount must have the `update` verb on `apps/deployments`. Charts shipped before this was fixed grant only `patch`, which causes the rollout step to fail. If you're on an older chart, see [Troubleshooting](#troubleshooting).
+</Note>
+
+## Run the migration
+
+<Steps>
+  <Step title="Open the instance detail page">
+    From the dashboard, click the instance you want to migrate. Legacy instances show a migration banner at the top of the page.
+  </Step>
+  <Step title="Click Migrate to on-demand browser">
+    The control plane runs the migration as a background task. A toast shows live progress: updating the database row, rolling out the new agent image, and recording the browser session.
+  </Step>
+  <Step title="Verify the new layout">
+    On the instance **Settings** tab, the **Agent Image** field shows `glukw/claworc-agent` (or whatever you configured). Open **Browser** to launch the on-demand Chrome session — the first start may take up to 60 seconds.
+  </Step>
+</Steps>
+
+## What gets preserved
+
+- Chrome profile, sign-ins, cookies, and extensions
+- Homebrew packages installed inside the agent
+- `openclaw.json` and other agent configuration
+- SSH keys and persistent home directory
+
+## Troubleshooting
+
+If the migration fails, the instance is automatically reverted to its legacy image so you can retry safely.
+
+### `default_agent_image setting is empty`
+
+The migrator stops before touching the instance. Open admin **Settings**, set `default_agent_image` (e.g. `glukw/claworc-agent:latest`), and click **Migrate** again.
+
+### `rollout new agent image: …`
+
+The new agent image could not be pulled. Make sure the tag exists in the registry your cluster or Docker host uses. For self-hosted setups, you can build the image locally:
+
+```bash
+docker build -f agent/Dockerfile.agent -t glukw/claworc-agent:latest agent/
+```
+
+Push it to your registry (or load it onto the node), then click **Migrate** again.
+
+### `cannot update resource "deployments"` (Kubernetes RBAC)
+
+The full error looks like:
+
+```text
+deployments.apps "bot-…" is forbidden: User "system:serviceaccount:claworc:claworc"
+cannot update resource "deployments" in API group "apps" in the namespace "claworc"
+```
+
+The control plane ServiceAccount is missing the `update` verb on Deployments. Pick one recovery path:
+
+- **Upgrade the Helm chart** (recommended) — the current chart grants `update`:
+
+  ```bash
+  helm upgrade claworc ./helm -n claworc
+  ```
+
+- **Or patch the live Role** without redeploying:
+
+  ```bash
+  kubectl patch role claworc -n claworc --type=json \
+    -p='[{"op":"replace","path":"/rules/0/verbs","value":["create","get","list","patch","update","delete"]}]'
+  ```
+
+Click **Migrate** again afterwards. The instance was reverted on the first failure, so the retry starts from a clean legacy state.


### PR DESCRIPTION
## Summary

- **Helm RBAC fix:** Added `update` to the verbs on `apps/deployments` in the `claworc` ServiceAccount Role. The legacy → on-demand browser migration code path calls `Deployments().Update(...)` (`control-plane/internal/orchestrator/kubernetes.go:288` and `:408`) and was failing on real clusters with:

  > `deployments.apps "bot-…" is forbidden: User "system:serviceaccount:claworc:claworc" cannot update resource "deployments" in API group "apps" in the namespace "claworc"`

- **New end-user docs:** `website_docs/migrating-on-demand-browser.mdx` — admin guide for migrating instances from the legacy combined image to the on-demand agent + browser layout. Covers prerequisites, step-by-step procedure, and troubleshooting for empty `default_agent_image`, image pull failures, and the RBAC 403 above (with both `helm upgrade` and `kubectl patch` recovery paths).

- Wired the new page into `docs.json` navigation; updated cross-links from `instances.mdx` and `accessing.mdx`.

These two changes ship together because the doc tells admins how to recover from exactly the bug the helm fix prevents.

## Test plan

- [ ] CI green (unit + integration tests, CodeQL, image builds)
- [ ] Mintlify docs build picks up the new page in the Instances group
- [ ] On a fresh cluster, `helm upgrade` applies the new Role and instance migration succeeds