### PR TITLE
Validate k8s resource quantities on Settings and Instance pages

### DIFF
--- a/control-plane/frontend/src/pages/InstanceDetailPage.tsx
+++ b/control-plane/frontend/src/pages/InstanceDetailPage.tsx
@@ -17,6 +17,13 @@ import SSHStatus from "@/components/SSHStatus";
 import SSHEventLog from "@/components/SSHEventLog";
 import SSHTroubleshoot from "@/components/SSHTroubleshoot";
 import {
+  isValidCPU,
+  isValidMemory,
+  isValidResolution,
+  cpuToMillis,
+  memToBytes,
+} from "@/utils/resourceValidation";
+import {
   useInstance,
   useStartInstance,
   useStopInstance,
@@ -301,11 +308,6 @@ export default function InstanceDetailPage() {
     );
   };
 
-  const isValidCPU = (v: string) => /^\d+m$/.test(v) || /^\d+(\.\d+)?$/.test(v);
-  const isValidMemory = (v: string) => /^\d+(Mi|Gi)$/.test(v);
-  const cpuToMillis = (v: string) => v.endsWith("m") ? parseInt(v) : parseFloat(v) * 1000;
-  const memToBytes = (v: string) => v.endsWith("Gi") ? parseInt(v) * 1024 : parseInt(v);
-  const isValidResolution = (v: string) => v === "" || /^\d+x\d+$/.test(v);
 
   const resourcesValid =
     isValidCPU(pendingCPURequest) &&

--- a/control-plane/frontend/src/pages/SettingsPage.tsx
+++ b/control-plane/frontend/src/pages/SettingsPage.tsx
@@ -10,6 +10,7 @@ import { useProviders, useCatalogIconMap } from "@/hooks/useProviders";
 import { fetchSSHFingerprint, rotateSSHKey } from "@/api/ssh";
 import { syncAllProviders } from "@/api/llm";
 import { successToast, errorToast } from "@/utils/toast";
+import { validateResourceQuantities } from "@/utils/resourceValidation";
 import type { LLMProvider } from "@/types/instance";
 
 import type { SettingsUpdatePayload } from "@/types/settings";
@@ -93,6 +94,7 @@ export default function SettingsPage() {
   };
 
   const handleSave = () => {
+    if (!resourcesValid) return;
     const payload: SettingsUpdatePayload = { ...resources };
     if (pendingBraveKey !== null) payload.brave_api_key = pendingBraveKey;
 
@@ -125,14 +127,33 @@ export default function SettingsPage() {
     await updateMutation.mutateAsync(payload);
   };
 
-  const resourceFields: { key: string; label: string }[] = [
-    { key: "default_cpu_request", label: "CPU Request" },
-    { key: "default_cpu_limit", label: "CPU Limit" },
-    { key: "default_memory_request", label: "Memory Request" },
-    { key: "default_memory_limit", label: "Memory Limit" },
-    { key: "default_storage_homebrew", label: "Homebrew Storage" },
-    { key: "default_storage_home", label: "Home Storage" },
+  const resourceFields: {
+    key: string;
+    label: string;
+    errorKey: "cpu_request" | "cpu_limit" | "memory_request" | "memory_limit" | "storage_home" | "storage_homebrew";
+  }[] = [
+    { key: "default_cpu_request", label: "CPU Request", errorKey: "cpu_request" },
+    { key: "default_cpu_limit", label: "CPU Limit", errorKey: "cpu_limit" },
+    { key: "default_memory_request", label: "Memory Request", errorKey: "memory_request" },
+    { key: "default_memory_limit", label: "Memory Limit", errorKey: "memory_limit" },
+    { key: "default_storage_homebrew", label: "Homebrew Storage", errorKey: "storage_homebrew" },
+    { key: "default_storage_home", label: "Home Storage", errorKey: "storage_home" },
   ];
+
+  const effective = (key: string): string => {
+    if (key in resources) return resources[key];
+    const v = (settings as Record<string, any>)[key];
+    return typeof v === "string" ? v : "";
+  };
+  const resourceErrors = validateResourceQuantities({
+    cpu_request: effective("default_cpu_request"),
+    cpu_limit: effective("default_cpu_limit"),
+    memory_request: effective("default_memory_request"),
+    memory_limit: effective("default_memory_limit"),
+    storage_home: effective("default_storage_home"),
+    storage_homebrew: effective("default_storage_homebrew"),
+  });
+  const resourcesValid = Object.keys(resourceErrors).length === 0;
 
   const hasChanges =
     pendingBraveKey !== null ||
@@ -316,18 +337,28 @@ export default function SettingsPage() {
               />
             </div>
             <div className="grid grid-cols-2 gap-4">
-              {resourceFields.map((field) => (
-                <div key={field.key}>
-                  <label className="block text-xs text-gray-500 mb-1">{field.label}</label>
-                  <input
-                    type="text"
-                    defaultValue={(settings as Record<string, any>)[field.key] ?? ""}
-                    onChange={(e) => setResources((r) => ({ ...r, [field.key]: e.target.value }))}
-                    className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  />
-                </div>
-              ))}
+              {resourceFields.map((field) => {
+                const err = resourceErrors[field.errorKey];
+                return (
+                  <div key={field.key}>
+                    <label className="block text-xs text-gray-500 mb-1">{field.label}</label>
+                    <input
+                      type="text"
+                      defaultValue={(settings as Record<string, any>)[field.key] ?? ""}
+                      onChange={(e) => setResources((r) => ({ ...r, [field.key]: e.target.value }))}
+                      className={`w-full px-3 py-1.5 border rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 ${err ? "border-red-300" : "border-gray-300"}`}
+                    />
+                    {err && <p className="mt-1 text-xs text-red-600">{err}</p>}
+                  </div>
+                );
+              })}
             </div>
+            {resourceErrors.cpu_pair && (
+              <p className="mt-2 text-xs text-red-600">{resourceErrors.cpu_pair}</p>
+            )}
+            {resourceErrors.memory_pair && (
+              <p className="mt-2 text-xs text-red-600">{resourceErrors.memory_pair}</p>
+            )}
           </div>
         </div>
 
@@ -478,7 +509,7 @@ export default function SettingsPage() {
         </button>
         <button
           onClick={handleSave}
-          disabled={updateMutation.isPending || !hasChanges}
+          disabled={updateMutation.isPending || !hasChanges || !resourcesValid}
           className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {updateMutation.isPending ? "Saving..." : "Save"}

--- a/control-plane/frontend/src/utils/resourceValidation.ts
+++ b/control-plane/frontend/src/utils/resourceValidation.ts
@@ -1,0 +1,76 @@
+// Validation helpers for Kubernetes-style resource quantity strings used by
+// instance and global-default settings. Mirrors the backend rules in
+// control-plane/internal/handlers/resourcevalidation.go.
+
+const CPU_RE = /^(\d+m|\d+(\.\d+)?)$/;
+const MEM_RE = /^\d+(Ki|Mi|Gi)$/;
+
+export const isValidCPU = (v: string): boolean => CPU_RE.test(v);
+export const isValidMemory = (v: string): boolean => MEM_RE.test(v);
+export const isValidStorage = isValidMemory;
+export const isValidResolution = (v: string): boolean => v === "" || /^\d+x\d+$/.test(v);
+
+export const cpuToMillis = (v: string): number => {
+  if (v.endsWith("m")) return parseInt(v, 10);
+  return parseFloat(v) * 1000;
+};
+
+export const memToBytes = (v: string): number => {
+  const n = parseInt(v, 10);
+  if (v.endsWith("Gi")) return n * 1024 * 1024 * 1024;
+  if (v.endsWith("Mi")) return n * 1024 * 1024;
+  if (v.endsWith("Ki")) return n * 1024;
+  return n;
+};
+
+export type ResourceQuantities = {
+  cpu_request?: string;
+  cpu_limit?: string;
+  memory_request?: string;
+  memory_limit?: string;
+  storage_home?: string;
+  storage_homebrew?: string;
+};
+
+// Returns a per-field error map. Empty values are treated as "not provided"
+// and skipped, matching the backend tolerance.
+export function validateResourceQuantities(
+  q: ResourceQuantities,
+): Partial<Record<keyof ResourceQuantities | "cpu_pair" | "memory_pair", string>> {
+  const errors: Partial<
+    Record<keyof ResourceQuantities | "cpu_pair" | "memory_pair", string>
+  > = {};
+
+  if (q.cpu_request && !isValidCPU(q.cpu_request))
+    errors.cpu_request = "e.g. 500m or 0.5";
+  if (q.cpu_limit && !isValidCPU(q.cpu_limit))
+    errors.cpu_limit = "e.g. 2000m or 2";
+  if (q.memory_request && !isValidMemory(q.memory_request))
+    errors.memory_request = "e.g. 1Gi or 512Mi";
+  if (q.memory_limit && !isValidMemory(q.memory_limit))
+    errors.memory_limit = "e.g. 4Gi or 2048Mi";
+  if (q.storage_home && !isValidStorage(q.storage_home))
+    errors.storage_home = "e.g. 10Gi";
+  if (q.storage_homebrew && !isValidStorage(q.storage_homebrew))
+    errors.storage_homebrew = "e.g. 10Gi";
+
+  if (
+    !errors.cpu_request &&
+    !errors.cpu_limit &&
+    q.cpu_request &&
+    q.cpu_limit &&
+    cpuToMillis(q.cpu_request) > cpuToMillis(q.cpu_limit)
+  ) {
+    errors.cpu_pair = "CPU request cannot exceed CPU limit";
+  }
+  if (
+    !errors.memory_request &&
+    !errors.memory_limit &&
+    q.memory_request &&
+    q.memory_limit &&
+    memToBytes(q.memory_request) > memToBytes(q.memory_limit)
+  ) {
+    errors.memory_pair = "Memory request cannot exceed memory limit";
+  }
+  return errors;
+}

--- a/control-plane/internal/handlers/instances.go
+++ b/control-plane/internal/handlers/instances.go
@@ -720,6 +720,18 @@ func CreateInstance(w http.ResponseWriter, r *http.Request) {
 	resolveDefault(&body.StorageHomebrew, "default_storage_homebrew", "10Gi")
 	resolveDefault(&body.StorageHome, "default_storage_home", "10Gi")
 
+	if err := ValidateResourceQuantities(ResourceQuantities{
+		CPURequest:      body.CPURequest,
+		CPULimit:        body.CPULimit,
+		MemoryRequest:   body.MemoryRequest,
+		MemoryLimit:     body.MemoryLimit,
+		StorageHome:     body.StorageHome,
+		StorageHomebrew: body.StorageHomebrew,
+	}); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
 	name := generateName(body.DisplayName)
 
 	// Check uniqueness
@@ -1045,33 +1057,6 @@ type instanceUpdateRequest struct {
 	BrowserStorage     *string           `json:"browser_storage"`      // non-legacy only
 }
 
-var (
-	cpuRegex        = regexp.MustCompile(`^(\d+m|\d+(\.\d+)?)$`)
-	memoryRegex     = regexp.MustCompile(`^\d+(Ki|Mi|Gi)$`)
-	resolutionRegex = regexp.MustCompile(`^\d+x\d+$`)
-)
-
-func cpuToMillicores(s string) int64 {
-	if strings.HasSuffix(s, "m") {
-		n, _ := strconv.ParseInt(s[:len(s)-1], 10, 64)
-		return n
-	}
-	f, _ := strconv.ParseFloat(s, 64)
-	return int64(f * 1000)
-}
-
-func memoryToBytes(s string) int64 {
-	unitMap := map[string]int64{"Ki": 1024, "Mi": 1024 * 1024, "Gi": 1024 * 1024 * 1024}
-	for suffix, multiplier := range unitMap {
-		if strings.HasSuffix(s, suffix) {
-			n, _ := strconv.ParseInt(s[:len(s)-len(suffix)], 10, 64)
-			return n * multiplier
-		}
-	}
-	n, _ := strconv.ParseInt(s, 10, 64)
-	return n
-}
-
 func UpdateInstance(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.Atoi(chi.URLParam(r, "id"))
 	if err != nil {
@@ -1213,40 +1198,25 @@ func UpdateInstance(w http.ResponseWriter, r *http.Request) {
 		memLim := inst.MemoryLimit
 
 		if body.CPURequest != nil {
-			if !cpuRegex.MatchString(*body.CPURequest) {
-				writeError(w, http.StatusBadRequest, "Invalid CPU request format (e.g., 500m or 0.5)")
-				return
-			}
 			cpuReq = *body.CPURequest
 		}
 		if body.CPULimit != nil {
-			if !cpuRegex.MatchString(*body.CPULimit) {
-				writeError(w, http.StatusBadRequest, "Invalid CPU limit format (e.g., 2000m or 2)")
-				return
-			}
 			cpuLim = *body.CPULimit
 		}
 		if body.MemoryRequest != nil {
-			if !memoryRegex.MatchString(*body.MemoryRequest) {
-				writeError(w, http.StatusBadRequest, "Invalid memory request format (e.g., 1Gi or 512Mi)")
-				return
-			}
 			memReq = *body.MemoryRequest
 		}
 		if body.MemoryLimit != nil {
-			if !memoryRegex.MatchString(*body.MemoryLimit) {
-				writeError(w, http.StatusBadRequest, "Invalid memory limit format (e.g., 4Gi or 2048Mi)")
-				return
-			}
 			memLim = *body.MemoryLimit
 		}
 
-		if cpuToMillicores(cpuReq) > cpuToMillicores(cpuLim) {
-			writeError(w, http.StatusBadRequest, "CPU request cannot exceed CPU limit")
-			return
-		}
-		if memoryToBytes(memReq) > memoryToBytes(memLim) {
-			writeError(w, http.StatusBadRequest, "Memory request cannot exceed memory limit")
+		if err := ValidateResourceQuantities(ResourceQuantities{
+			CPURequest:    cpuReq,
+			CPULimit:      cpuLim,
+			MemoryRequest: memReq,
+			MemoryLimit:   memLim,
+		}); err != nil {
+			writeError(w, http.StatusBadRequest, err.Error())
 			return
 		}
 

--- a/control-plane/internal/handlers/resourcevalidation.go
+++ b/control-plane/internal/handlers/resourcevalidation.go
@@ -1,0 +1,80 @@
+package handlers
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	cpuRegex        = regexp.MustCompile(`^(\d+m|\d+(\.\d+)?)$`)
+	memoryRegex     = regexp.MustCompile(`^\d+(Ki|Mi|Gi)$`)
+	resolutionRegex = regexp.MustCompile(`^\d+x\d+$`)
+)
+
+func cpuToMillicores(s string) int64 {
+	if strings.HasSuffix(s, "m") {
+		n, _ := strconv.ParseInt(s[:len(s)-1], 10, 64)
+		return n
+	}
+	f, _ := strconv.ParseFloat(s, 64)
+	return int64(f * 1000)
+}
+
+func memoryToBytes(s string) int64 {
+	unitMap := map[string]int64{"Ki": 1024, "Mi": 1024 * 1024, "Gi": 1024 * 1024 * 1024}
+	for suffix, multiplier := range unitMap {
+		if strings.HasSuffix(s, suffix) {
+			n, _ := strconv.ParseInt(s[:len(s)-len(suffix)], 10, 64)
+			return n * multiplier
+		}
+	}
+	n, _ := strconv.ParseInt(s, 10, 64)
+	return n
+}
+
+// ResourceQuantities holds the six string values that get validated together.
+// Empty strings are treated as "not provided" and skipped.
+type ResourceQuantities struct {
+	CPURequest      string
+	CPULimit        string
+	MemoryRequest   string
+	MemoryLimit     string
+	StorageHome     string
+	StorageHomebrew string
+}
+
+// ValidateResourceQuantities checks each provided field against the expected
+// k8s-quantity format and enforces request <= limit when both sides are
+// present. It returns a user-facing error suitable for a 400 response.
+func ValidateResourceQuantities(q ResourceQuantities) error {
+	if q.CPURequest != "" && !cpuRegex.MatchString(q.CPURequest) {
+		return fmt.Errorf("Invalid CPU request format (e.g., 500m or 0.5)")
+	}
+	if q.CPULimit != "" && !cpuRegex.MatchString(q.CPULimit) {
+		return fmt.Errorf("Invalid CPU limit format (e.g., 2000m or 2)")
+	}
+	if q.MemoryRequest != "" && !memoryRegex.MatchString(q.MemoryRequest) {
+		return fmt.Errorf("Invalid memory request format (e.g., 1Gi or 512Mi)")
+	}
+	if q.MemoryLimit != "" && !memoryRegex.MatchString(q.MemoryLimit) {
+		return fmt.Errorf("Invalid memory limit format (e.g., 4Gi or 2048Mi)")
+	}
+	if q.StorageHome != "" && !memoryRegex.MatchString(q.StorageHome) {
+		return fmt.Errorf("Invalid home storage format (e.g., 10Gi or 512Mi)")
+	}
+	if q.StorageHomebrew != "" && !memoryRegex.MatchString(q.StorageHomebrew) {
+		return fmt.Errorf("Invalid homebrew storage format (e.g., 10Gi or 512Mi)")
+	}
+
+	if q.CPURequest != "" && q.CPULimit != "" &&
+		cpuToMillicores(q.CPURequest) > cpuToMillicores(q.CPULimit) {
+		return fmt.Errorf("CPU request cannot exceed CPU limit")
+	}
+	if q.MemoryRequest != "" && q.MemoryLimit != "" &&
+		memoryToBytes(q.MemoryRequest) > memoryToBytes(q.MemoryLimit) {
+		return fmt.Errorf("Memory request cannot exceed memory limit")
+	}
+	return nil
+}

--- a/control-plane/internal/handlers/resourcevalidation_test.go
+++ b/control-plane/internal/handlers/resourcevalidation_test.go
@@ -1,0 +1,39 @@
+package handlers
+
+import "testing"
+
+func TestValidateResourceQuantities(t *testing.T) {
+	cases := []struct {
+		name    string
+		q       ResourceQuantities
+		wantErr bool
+	}{
+		{"all empty", ResourceQuantities{}, false},
+		{"valid full", ResourceQuantities{
+			CPURequest: "500m", CPULimit: "2000m",
+			MemoryRequest: "1Gi", MemoryLimit: "4Gi",
+			StorageHome: "10Gi", StorageHomebrew: "10Gi",
+		}, false},
+		{"cpu decimal valid", ResourceQuantities{CPURequest: "0.5", CPULimit: "2"}, false},
+		{"cpu junk", ResourceQuantities{CPURequest: "half"}, true},
+		{"memory wrong unit", ResourceQuantities{MemoryRequest: "500Mb"}, true},
+		{"memory bare int", ResourceQuantities{MemoryRequest: "500"}, true},
+		{"memory Ki ok", ResourceQuantities{MemoryRequest: "1024Ki", MemoryLimit: "1Mi"}, false},
+		{"storage wrong unit", ResourceQuantities{StorageHome: "10G"}, true},
+		{"storage homebrew junk", ResourceQuantities{StorageHomebrew: "10gb"}, true},
+		{"cpu req gt limit", ResourceQuantities{CPURequest: "3000m", CPULimit: "2000m"}, true},
+		{"mem req gt limit", ResourceQuantities{MemoryRequest: "8Gi", MemoryLimit: "4Gi"}, true},
+		{"req present limit empty (skip pair)", ResourceQuantities{CPURequest: "500m"}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateResourceQuantities(tc.q)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/control-plane/internal/handlers/settings.go
+++ b/control-plane/internal/handlers/settings.go
@@ -117,6 +117,26 @@ func UpdateSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	resourceFromRaw := func(key string) string {
+		if v, ok := raw[key]; ok {
+			if s, ok := v.(string); ok {
+				return s
+			}
+		}
+		return ""
+	}
+	if err := ValidateResourceQuantities(ResourceQuantities{
+		CPURequest:      resourceFromRaw("default_cpu_request"),
+		CPULimit:        resourceFromRaw("default_cpu_limit"),
+		MemoryRequest:   resourceFromRaw("default_memory_request"),
+		MemoryLimit:     resourceFromRaw("default_memory_limit"),
+		StorageHome:     resourceFromRaw("default_storage_home"),
+		StorageHomebrew: resourceFromRaw("default_storage_homebrew"),
+	}); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
 	// Handle default_models
 	if v, ok := raw["default_models"]; ok {
 		b, err := json.Marshal(v)

--- a/control-plane/internal/handlers/settings_test.go
+++ b/control-plane/internal/handlers/settings_test.go
@@ -110,6 +110,22 @@ func TestUpdateSettings_PlainSetting(t *testing.T) {
 	}
 }
 
+func TestUpdateSettings_RejectsInvalidMemoryQuantity(t *testing.T) {
+	setupSettingsTest(t)
+
+	w := httptest.NewRecorder()
+	UpdateSettings(w, postJSON("/api/v1/settings", map[string]string{
+		"default_memory_request": "500Mb",
+	}))
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", w.Code)
+	}
+	if val, _ := database.GetSetting("default_memory_request"); val == "500Mb" {
+		t.Errorf("invalid value was persisted: %q", val)
+	}
+}
+
 func TestUpdateSettings_BraveKey_EncryptsAndMasks(t *testing.T) {
 	setupSettingsTest(t)
 


### PR DESCRIPTION
## Summary

A user just got an instance stuck in `creating` because `memory_request` was saved as `500Mb` (invalid k8s quantity — must be `Mi`/`Gi`). The orchestrator silently failed to create the Deployment with no log indicating why. This PR catches invalid values at the input boundary on every entry point.

## Backend
- New `internal/handlers/resourcevalidation.go` exports `ValidateResourceQuantities` plus the shared regex / unit-conversion helpers (moved out of `instances.go`).
- `CreateInstance`, `UpdateInstance`, and `UpdateSettings` now reject invalid k8s resource quantities with `400` instead of silently persisting them.
- New unit tests in `resourcevalidation_test.go` and a wiring test in `settings_test.go`.

## Frontend
- New `src/utils/resourceValidation.ts` with shared `isValidCPU` / `isValidMemory` / `isValidStorage` / `isValidResolution` plus `cpuToMillis` / `memToBytes` / `validateResourceQuantities`.
- `InstanceDetailPage.tsx` now imports the shared helpers (no behavior change).
- `SettingsPage.tsx` shows red borders + inline errors per field, pair-mismatch messages, and disables Save when invalid.

## Test plan
- [x] `go test ./internal/handlers/ -count=1` — all green locally
- [x] `cd control-plane/frontend && npx vite build` — succeeds
- [ ] CI passes on this branch
- [ ] Main CI stays green after merge