### PR TITLE
ci(agent): test all docker images before pushing on main

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install test dependencies
         run: make install-test
 
-      - name: Build, test and push the image
-        run: make agent
+      - name: Build, test, and push agent images
+        run: make agent-ci
         env:
           CACHE_ARGS: --cache-from type=gha,scope=agent --cache-to type=gha,mode=max,scope=agent

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ KUBECONFIG := ../kubeconfig
 HELM_RELEASE := claworc
 HELM_NAMESPACE := claworc
 
-.PHONY: agent agent-base agent-base-china agent-build agent-test agent-push agent-exec dashboard docker-prune release \
+.PHONY: agent agent-ci agent-base agent-base-china agent-build agent-test agent-push agent-exec dashboard docker-prune release \
 	helm-install helm-upgrade helm-uninstall helm-template install-dev dev dev-docs \
 	pull-agent local-build local-up local-down local-logs local-clean control-plane \
 	ssh-integration-test ssh-file-integration-test test-integration-backend extract-models scrape-models test \
@@ -30,6 +30,12 @@ HELM_NAMESPACE := claworc
 	e2e e2e-debug e2e-install
 
 agent: agent-base agent-push
+
+# CI entry point: build base image, build all variants locally, run vitest
+# against the loaded images, and only push if tests pass. Used by
+# .github/workflows/agent.yml on the main branch.
+agent-ci: agent-base agent-build agent-test agent-push
+	@echo "Agent images built, tested, and pushed."
 
 agent-base:
 	@echo "Building and pushing browser-base image..."
@@ -47,7 +53,8 @@ agent-build:
 	docker buildx build --platform linux/$(NATIVE_ARCH) $(CACHE_ARGS) --build-arg BASE_IMAGE=$(BROWSER_BASE_IMAGE):$(TAG) -t $(BROWSER_BRAVE_IMAGE):$(TAG) -f agent/browser/Dockerfile.brave --load agent/browser/
 
 agent-test:
-	cd agent/tests && AGENT_TEST_IMAGE=$(BROWSER_CHROMIUM_IMAGE):$(TAG) \
+	cd agent/tests && AGENT_INSTANCE_TEST_IMAGE=$(AGENT_IMAGE):$(TAG) \
+		AGENT_TEST_IMAGE=$(BROWSER_CHROMIUM_IMAGE):$(TAG) \
 		AGENT_CHROME_TEST_IMAGE=$(BROWSER_CHROME_IMAGE):$(TAG) \
 		AGENT_BRAVE_TEST_IMAGE=$(BROWSER_BRAVE_IMAGE):$(TAG) \
 		npm run test

--- a/agent/instance/Dockerfile
+++ b/agent/instance/Dockerfile
@@ -35,7 +35,11 @@ RUN apt-get update && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen && \
     if [ "$USE_CHINA_MIRRORS" = "true" ]; then npm config set registry https://registry.npmmirror.com; fi && \
     npm install -g openclaw@latest && \
-    (cd "$(npm root -g)/openclaw" && npm rebuild sharp) && \
+    # OpenClaw lists `sharp` only under pnpm's `onlyBuiltDependencies`, not
+    # `dependencies`, so `npm install -g openclaw` never installs it. The
+    # image pipeline (Telegram, screenshots) lazy-imports `sharp` at runtime
+    # — without this step it throws ERR_MODULE_NOT_FOUND. See issue #127.
+    (cd "$(npm root -g)/openclaw" && npm install --no-save sharp) && \
     curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local python3 - && \
     rm -rf /var/lib/apt/lists/*
 

--- a/agent/instance/Dockerfile
+++ b/agent/instance/Dockerfile
@@ -30,10 +30,12 @@ RUN apt-get update && \
       tzdata locales \
       openssh-server git python3 python3-pip python3-venv python3-numpy python-is-python3 \
       build-essential procps cron nodejs \
+      libvips42 \
       sudo && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen && \
     if [ "$USE_CHINA_MIRRORS" = "true" ]; then npm config set registry https://registry.npmmirror.com; fi && \
     npm install -g openclaw@latest && \
+    (cd "$(npm root -g)/openclaw" && npm rebuild sharp) && \
     curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local python3 - && \
     rm -rf /var/lib/apt/lists/*
 

--- a/agent/tests/__snapshots__/openclaw.test.ts.snap
+++ b/agent/tests/__snapshots__/openclaw.test.ts.snap
@@ -46,17 +46,150 @@ exports[`agent image > openclaw.json structure matches snapshot 1`] = `
     "lastTouchedAt": "string",
     "lastTouchedVersion": "string",
   },
-  "plugins": {
-    "entries": {
-      "browser": {
-        "enabled": "boolean",
-      },
-    },
-  },
   "session": {
     "dmScope": "string",
   },
   "skills": {
+    "entries": {
+      "1password": {
+        "enabled": "boolean",
+      },
+      "apple-notes": {
+        "enabled": "boolean",
+      },
+      "apple-reminders": {
+        "enabled": "boolean",
+      },
+      "bear-notes": {
+        "enabled": "boolean",
+      },
+      "blogwatcher": {
+        "enabled": "boolean",
+      },
+      "blucli": {
+        "enabled": "boolean",
+      },
+      "bluebubbles": {
+        "enabled": "boolean",
+      },
+      "camsnap": {
+        "enabled": "boolean",
+      },
+      "clawhub": {
+        "enabled": "boolean",
+      },
+      "coding-agent": {
+        "enabled": "boolean",
+      },
+      "discord": {
+        "enabled": "boolean",
+      },
+      "eightctl": {
+        "enabled": "boolean",
+      },
+      "gemini": {
+        "enabled": "boolean",
+      },
+      "gh-issues": {
+        "enabled": "boolean",
+      },
+      "gifgrep": {
+        "enabled": "boolean",
+      },
+      "github": {
+        "enabled": "boolean",
+      },
+      "gog": {
+        "enabled": "boolean",
+      },
+      "goplaces": {
+        "enabled": "boolean",
+      },
+      "himalaya": {
+        "enabled": "boolean",
+      },
+      "imsg": {
+        "enabled": "boolean",
+      },
+      "mcporter": {
+        "enabled": "boolean",
+      },
+      "model-usage": {
+        "enabled": "boolean",
+      },
+      "nano-pdf": {
+        "enabled": "boolean",
+      },
+      "notion": {
+        "enabled": "boolean",
+      },
+      "obsidian": {
+        "enabled": "boolean",
+      },
+      "openai-whisper": {
+        "enabled": "boolean",
+      },
+      "openai-whisper-api": {
+        "enabled": "boolean",
+      },
+      "openhue": {
+        "enabled": "boolean",
+      },
+      "oracle": {
+        "enabled": "boolean",
+      },
+      "ordercli": {
+        "enabled": "boolean",
+      },
+      "peekaboo": {
+        "enabled": "boolean",
+      },
+      "sag": {
+        "enabled": "boolean",
+      },
+      "session-logs": {
+        "enabled": "boolean",
+      },
+      "sherpa-onnx-tts": {
+        "enabled": "boolean",
+      },
+      "slack": {
+        "enabled": "boolean",
+      },
+      "songsee": {
+        "enabled": "boolean",
+      },
+      "sonoscli": {
+        "enabled": "boolean",
+      },
+      "spotify-player": {
+        "enabled": "boolean",
+      },
+      "summarize": {
+        "enabled": "boolean",
+      },
+      "things-mac": {
+        "enabled": "boolean",
+      },
+      "tmux": {
+        "enabled": "boolean",
+      },
+      "trello": {
+        "enabled": "boolean",
+      },
+      "video-frames": {
+        "enabled": "boolean",
+      },
+      "voice-call": {
+        "enabled": "boolean",
+      },
+      "wacli": {
+        "enabled": "boolean",
+      },
+      "xurl": {
+        "enabled": "boolean",
+      },
+    },
     "install": {
       "nodeManager": "string",
     },

--- a/agent/tests/global-setup.ts
+++ b/agent/tests/global-setup.ts
@@ -8,6 +8,9 @@ import { execFileSync } from "node:child_process";
 import type { ContainerMap } from "./helpers";
 
 const IMAGES: Record<string, string> = {
+  // Instance image: OpenClaw + sshd + cron, no browser. openclaw / cron /
+  // sharp / libvips test suites run against this one.
+  agent: process.env.AGENT_INSTANCE_TEST_IMAGE ?? "claworc-agent:test",
   chromium: process.env.AGENT_TEST_IMAGE ?? "openclaw-vnc-chromium:test",
   chrome: process.env.AGENT_CHROME_TEST_IMAGE ?? "openclaw-vnc-chrome:test",
   brave: process.env.AGENT_BRAVE_TEST_IMAGE ?? "openclaw-vnc-brave:test",
@@ -180,21 +183,37 @@ export async function setup(): Promise<void> {
 
   // Wait for readiness in parallel
   const readinessPromises = Object.entries(launched).map(async ([browser, { name }]) => {
-    const pattern = BROWSER_PROCESS_PATTERNS[browser] ?? browser;
+    if (browser === "agent") {
+      // Instance image has no browser and no CDP listener — it's the
+      // OpenClaw gateway + sshd + cron only. Wait for openclaw to be on
+      // PATH; the SSH wait below is shared with browser images.
+      const ready = await waitForProcess(name, "/init", 300_000);
+      if (!ready) {
+        dumpDiagnostics(name);
+        throw new Error(`[global-setup] agent /init did not start within 300s`);
+      }
+      const cmd = exec(name, ["sh", "-c", "command -v openclaw"]);
+      if (cmd.exitCode !== 0) {
+        dumpDiagnostics(name);
+        throw new Error(`[global-setup] openclaw not on PATH in agent container`);
+      }
+    } else {
+      const pattern = BROWSER_PROCESS_PATTERNS[browser] ?? browser;
 
-    // All images: wait for browser process.
-    // Generous timeouts because multiple containers under QEMU compete for CPU.
-    const browserOk = await waitForProcess(name, pattern, 300_000);
-    if (!browserOk) {
-      dumpDiagnostics(name);
-      throw new Error(`[global-setup] ${browser} process did not start within 300s`);
-    }
+      // Wait for browser process.
+      // Generous timeouts because multiple containers under QEMU compete for CPU.
+      const browserOk = await waitForProcess(name, pattern, 300_000);
+      if (!browserOk) {
+        dumpDiagnostics(name);
+        throw new Error(`[global-setup] ${browser} process did not start within 300s`);
+      }
 
-    // All images: wait for CDP port 9222
-    const cdpOk = await waitForCDP(name, 180_000);
-    if (!cdpOk) {
-      dumpDiagnostics(name);
-      throw new Error(`[global-setup] CDP port 9222 not ready for ${browser} within 180s`);
+      // Wait for CDP port 9222
+      const cdpOk = await waitForCDP(name, 180_000);
+      if (!cdpOk) {
+        dumpDiagnostics(name);
+        throw new Error(`[global-setup] CDP port 9222 not ready for ${browser} within 180s`);
+      }
     }
 
     // Note: openclaw gateway readiness is NOT checked here because

--- a/agent/tests/openclaw.test.ts
+++ b/agent/tests/openclaw.test.ts
@@ -152,4 +152,37 @@ describe.skipIf(!container)("agent image", { timeout: 300_000 }, () => {
     const result = execAsUser(container!, "openclaw gateway stop");
     expect(result.exitCode).toBeDefined();
   });
+
+  // Regression for https://github.com/gluk-w/claworc/issues/127. sharp is a
+  // native addon (libvips) used by openclaw's image pipeline (Telegram,
+  // screenshots). It silently went missing when sharp 0.34 switched to
+  // prebuilt binaries that need libvips on the system.
+  describe("sharp image dependency (issue #127)", () => {
+    const cdOpenclaw = 'cd "$(npm root -g)/openclaw"';
+
+    it("openclaw still declares sharp as a dependency", () => {
+      // If upstream openclaw drops sharp, the runtime check below loses its
+      // meaning — surface that change so we can revisit the Dockerfile.
+      const result = exec(container!, [
+        "bash",
+        "-c",
+        `${cdOpenclaw} && node -e "const p=require('./package.json'); const v=(p.dependencies&&p.dependencies.sharp)||(p.optionalDependencies&&p.optionalDependencies.sharp)||(p.peerDependencies&&p.peerDependencies.sharp); if(!v){process.exit(2)} console.log(v)"`,
+      ]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toMatch(/\d/);
+    });
+
+    it("openclaw can load sharp for image processing", () => {
+      // Resolve sharp the same way openclaw does at runtime — from its own
+      // node_modules — so this fails loudly if libvips is missing or the
+      // native binding didn't get built.
+      const result = exec(container!, [
+        "bash",
+        "-c",
+        `${cdOpenclaw} && node -e "console.log(require('sharp').versions.sharp)"`,
+      ]);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+    });
+  });
 });

--- a/agent/tests/openclaw.test.ts
+++ b/agent/tests/openclaw.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { exec, execAsUser, sleep, getContainers, hasCommand, dumpDiagnostics } from "./helpers";
+import { exec, execAsUser, sleep, getContainers, dumpDiagnostics } from "./helpers";
 
 const containers = getContainers();
 // openclaw lives in the claworc-agent image only. Browser-only images
-// (claworc-browser-*) don't ship the gateway, so this suite must skip
-// against them. Capability-probe the chromium container at module load.
-const chromiumName = containers.chromium?.name;
-const container = chromiumName && hasCommand(chromiumName, "openclaw") ? chromiumName : undefined;
+// (claworc-browser-*) don't ship the gateway, so this suite runs against
+// the dedicated `agent` container launched by global-setup.ts when the
+// instance image is available locally.
+const container = containers.agent?.name;
 
 function structureOf(obj: any): any {
   if (Array.isArray(obj)) return obj.length > 0 ? [structureOf(obj[0])] : [];
@@ -160,16 +160,18 @@ describe.skipIf(!container)("agent image", { timeout: 300_000 }, () => {
   describe("sharp image dependency (issue #127)", () => {
     const cdOpenclaw = 'cd "$(npm root -g)/openclaw"';
 
-    it("openclaw still declares sharp as a dependency", () => {
+    it("openclaw still declares sharp as a build dependency", () => {
       // If upstream openclaw drops sharp, the runtime check below loses its
       // meaning — surface that change so we can revisit the Dockerfile.
+      // openclaw lists sharp under pnpm's `onlyBuiltDependencies` rather
+      // than `dependencies`/`optional`/`peer`, so check all four locations.
       const result = exec(container!, [
         "bash",
         "-c",
-        `${cdOpenclaw} && node -e "const p=require('./package.json'); const v=(p.dependencies&&p.dependencies.sharp)||(p.optionalDependencies&&p.optionalDependencies.sharp)||(p.peerDependencies&&p.peerDependencies.sharp); if(!v){process.exit(2)} console.log(v)"`,
+        `${cdOpenclaw} && node -e "const p=require('./package.json'); const inField=(o)=>o&&(o.sharp||(Array.isArray(o)&&o.includes('sharp'))); const found=inField(p.dependencies)||inField(p.optionalDependencies)||inField(p.peerDependencies)||inField(p.pnpm&&p.pnpm.onlyBuiltDependencies); if(!found){process.exit(2)} console.log('ok')"`,
       ]);
       expect(result.exitCode).toBe(0);
-      expect(result.stdout.trim()).toMatch(/\d/);
+      expect(result.stdout.trim()).toBe("ok");
     });
 
     it("openclaw can load sharp for image processing", () => {


### PR DESCRIPTION
## Summary

- Run the agent test suite against locally-built copies of all 4 images (base + 3 browser images, plus the instance image) on every push to `main`, and gate the Docker Hub push on those tests passing.
- Add a fourth `agent` test container for the instance image with its own readiness probe (waits for `openclaw` on PATH; no browser/CDP), and gate `openclaw.test.ts` on it directly.
- Fix sharp install in the instance image: replace the no-op `npm rebuild sharp` with `npm install --no-save sharp` inside openclaw's install dir, since sharp lives in `pnpm.onlyBuiltDependencies` rather than `dependencies`. The sharp dependency check now also looks there.
- Refresh the `openclaw.json` snapshot to match upstream's `plugins → skills` rename (structure-only check).

## Why

PR #128 (the previous sharp fix) shipped without any tests running in CI — the workflow built and pushed images directly. This change introduces a `make agent-ci` umbrella (`agent-base → agent-build → agent-test → agent-push`) so untested images can no longer reach Docker Hub.