### PR TITLE
fix(agent-tests): skip browser suite on instance image

### DIFF
--- a/agent/tests/browser.test.ts
+++ b/agent/tests/browser.test.ts
@@ -9,10 +9,13 @@ const BROWSER_PROCESS_PATTERNS: Record<string, string> = {
   brave: "brave-browser",
 };
 
-// Build describe.each entries from containers launched by global-setup
-const entries = Object.entries(containers).map(
-  ([browser, info]) => [browser, info.name] as [string, string],
-);
+// Build describe.each entries from containers launched by global-setup.
+// The `agent` (instance) image has no browser / CDP / stealth extension —
+// it ships OpenClaw + sshd + cron only — so exclude it here. openclaw.test.ts
+// is the suite that exercises that container.
+const entries = Object.entries(containers)
+  .filter(([browser]) => browser in BROWSER_PROCESS_PATTERNS)
+  .map(([browser, info]) => [browser, info.name] as [string, string]);
 
 // When no containers are available (no images built), skip all tests.
 // We must have at least one describe block to avoid vitest "no test suite" error.


### PR DESCRIPTION
## Summary

- Filter `browser.test.ts` to only run against containers that actually ship a browser, fixing a regression introduced by PR #129.
- After #129 added a fourth `agent` test container for the instance image (OpenClaw + sshd + cron, no browser / CDP / stealth extension), the four `browser.test.ts` cases — process-running, CDP `/json/version`, CDP `/json/list`, stealth-extension manifest — were running and failing against it. The suite now keys off `BROWSER_PROCESS_PATTERNS`, mirroring the capability-gating pattern already used in `crontab.test.ts`.

## Why

Caught by the post-merge `agent.yml` run for #129 — exactly the failure mode that change was designed to surface (untested images now block the Docker Hub push). Confirmed via the failed run: 148/152 tests passed, all 4 failures were `browser: agent`.