### PR TITLE
Add first-run onboarding wizard

### DIFF
--- a/.github/workflows/test-installers.yml
+++ b/.github/workflows/test-installers.yml
@@ -52,12 +52,6 @@ jobs:
           send "/tmp/claworc-test\r"
           expect "Proceed?"
           send "y\r"
-          expect "Admin username"
-          send "admin\r"
-          expect "Admin password:"
-          send "testpass123\r"
-          expect "Confirm password:"
-          send "testpass123\r"
           expect eof
           EXPECT_EOF
 
@@ -173,12 +167,6 @@ jobs:
           send "/tmp/claworc-test\r"
           expect "Proceed?"
           send "y\r"
-          expect "Admin username"
-          send "admin\r"
-          expect "Admin password:"
-          send "testpass123\r"
-          expect "Confirm password:"
-          send "testpass123\r"
           expect eof
           EXPECT_EOF
 
@@ -257,10 +245,7 @@ jobs:
             "",            # Port (default)
             "$env:TEMP\claworc-test",  # Data dir
             "y",           # Proceed
-            "",            # Remove existing (if any)
-            "admin",       # Admin username
-            "testpass123", # Password
-            "testpass123"  # Confirm password
+            ""             # Remove existing (if any)
           )
 
           function Read-Host {

--- a/Makefile
+++ b/Makefile
@@ -210,7 +210,7 @@ test:
 # file name from what changed. See docs/migrations.md.
 migration:
 	@command -v claude >/dev/null 2>&1 || { echo "error: 'claude' CLI not found in PATH"; exit 1; }
-	claude -p "Use the migration-author subagent to generate the next versioned Go migration based on current GORM model changes. Read the agent definition at .claude/agents/migration-author.md and follow its instructions exactly."
+	claude -p --agent migration-author "Generate the next versioned Go migration based on current GORM model changes. Follow your agent instructions exactly."
 
 # Apply all migrations against a fresh in-memory SQLite database and
 # assert the resulting schema covers every model. CI runs this on every

--- a/control-plane/frontend/src/App.tsx
+++ b/control-plane/frontend/src/App.tsx
@@ -1,10 +1,12 @@
 import { Routes, Route, Navigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import Layout from "./components/Layout";
 import DashboardPage from "./pages/DashboardPage";
 import CreateInstancePage from "./pages/CreateInstancePage";
 import InstanceDetailPage from "./pages/InstanceDetailPage";
 import SettingsPage from "./pages/SettingsPage";
 import LoginPage from "./pages/LoginPage";
+import OnboardingPage from "./pages/OnboardingPage";
 import BackendUnavailablePage from "./pages/BackendUnavailablePage";
 import UsersPage from "./pages/UsersPage";
 import TeamsPage from "./pages/TeamsPage";
@@ -17,6 +19,16 @@ import BackupsPage from "./pages/BackupsPage";
 import SharedFoldersPage from "./pages/SharedFoldersPage";
 import KanbanPage from "./pages/KanbanPage";
 import { useAuth } from "./contexts/AuthContext";
+import { checkSetupRequired } from "./api/auth";
+
+function useSetupRequired() {
+  return useQuery({
+    queryKey: ["auth", "setup-required"],
+    queryFn: checkSetupRequired,
+    retry: false,
+    staleTime: 30_000,
+  });
+}
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { user, isLoading, isBackendUnavailable } = useAuth();
@@ -50,6 +62,19 @@ function InstanceCreatorRoute({ children }: { children: React.ReactNode }) {
 }
 
 export default function App() {
+  const { data: setupRequired, isLoading: setupLoading } = useSetupRequired();
+
+  if (setupLoading) return null;
+
+  if (setupRequired) {
+    return (
+      <Routes>
+        <Route path="/" element={<OnboardingPage />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    );
+  }
+
   return (
     <Routes>
       <Route path="/login" element={<LoginRoute />} />

--- a/control-plane/frontend/src/pages/LoginPage.tsx
+++ b/control-plane/frontend/src/pages/LoginPage.tsx
@@ -1,11 +1,9 @@
-import { useState, useEffect, type FormEvent } from "react";
+import { useState, type FormEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import { Fingerprint } from "lucide-react";
 import { isAxiosError } from "axios";
 import { useAuth } from "@/contexts/AuthContext";
 import {
-  checkSetupRequired,
-  setupCreateAdmin,
   webAuthnLoginBegin,
   webAuthnLoginFinish,
 } from "@/api/auth";
@@ -24,35 +22,13 @@ function getLoginError(error: unknown): string {
   return "Sign in failed. Please try again.";
 }
 
-function getSetupError(error: unknown): string {
-  const networkOrServer = getNetworkOrServerError(error);
-  if (networkOrServer) return networkOrServer;
-  if (isAxiosError(error)) {
-    const detail = error.response?.data?.detail;
-    if (typeof detail === "string") return detail;
-  }
-  return "Failed to create admin account";
-}
-
 export default function LoginPage() {
   const { login, refetch } = useAuth();
   const navigate = useNavigate();
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
-  const [setupMode, setSetupMode] = useState(false);
-  const [checking, setChecking] = useState(true);
-
-  useEffect(() => {
-    checkSetupRequired()
-      .then((required) => {
-        setSetupMode(required);
-        setChecking(false);
-      })
-      .catch(() => setChecking(false));
-  }, []);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
@@ -60,21 +36,10 @@ export default function LoginPage() {
     setLoading(true);
 
     try {
-      if (setupMode) {
-        if (password !== confirmPassword) {
-          setError("Passwords do not match");
-          setLoading(false);
-          return;
-        }
-        await setupCreateAdmin({ username, password });
-        refetch();
-        navigate("/");
-      } else {
-        await login({ username, password });
-        navigate("/");
-      }
+      await login({ username, password });
+      navigate("/");
     } catch (err) {
-      setError(setupMode ? getSetupError(err) : getLoginError(err));
+      setError(getLoginError(err));
     } finally {
       setLoading(false);
     }
@@ -99,25 +64,15 @@ export default function LoginPage() {
     }
   };
 
-  if (checking) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="text-gray-500">Loading...</div>
-      </div>
-    );
-  }
-
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <div className="w-full max-w-sm">
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
           <h1 data-testid="login-title" className="text-xl font-semibold text-gray-900 text-center mb-1">
-            {setupMode ? "Create Admin Account" : "Sign In"}
+            Sign In
           </h1>
           <p className="text-sm text-gray-500 text-center mb-6">
-            {setupMode
-              ? "Set up your first admin account to get started"
-              : "OpenClaw Orchestrator"}
+            OpenClaw Orchestrator
           </p>
 
           {error && (
@@ -153,60 +108,36 @@ export default function LoginPage() {
                 onChange={(e) => setPassword(e.target.value)}
                 className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 required
-                autoComplete={setupMode ? "new-password" : "current-password"}
+                autoComplete="current-password"
               />
             </div>
-            {setupMode && (
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Confirm Password
-                </label>
-                <input
-                  data-testid="confirm-password-input"
-                  type="password"
-                  value={confirmPassword}
-                  onChange={(e) => setConfirmPassword(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                  required
-                  autoComplete="new-password"
-                />
-              </div>
-            )}
             <button
               data-testid="login-submit-button"
               type="submit"
               disabled={loading}
               className="w-full px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
             >
-              {loading
-                ? "Please wait..."
-                : setupMode
-                  ? "Create Admin Account"
-                  : "Sign In"}
+              {loading ? "Please wait..." : "Sign In"}
             </button>
           </form>
 
-          {!setupMode && (
-            <>
-              <div className="relative my-4">
-                <div className="absolute inset-0 flex items-center">
-                  <div className="w-full border-t border-gray-200" />
-                </div>
-                <div className="relative flex justify-center text-xs">
-                  <span className="bg-white px-2 text-gray-400">or</span>
-                </div>
-              </div>
-              <button
-                data-testid="passkey-login-button"
-                onClick={handlePasskeyLogin}
-                disabled={loading}
-                className="w-full px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 flex items-center justify-center gap-2"
-              >
-                <Fingerprint size={16} />
-                Sign in with Passkey
-              </button>
-            </>
-          )}
+          <div className="relative my-4">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-200" />
+            </div>
+            <div className="relative flex justify-center text-xs">
+              <span className="bg-white px-2 text-gray-400">or</span>
+            </div>
+          </div>
+          <button
+            data-testid="passkey-login-button"
+            onClick={handlePasskeyLogin}
+            disabled={loading}
+            className="w-full px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50 flex items-center justify-center gap-2"
+          >
+            <Fingerprint size={16} />
+            Sign in with Passkey
+          </button>
         </div>
       </div>
     </div>

--- a/control-plane/frontend/src/pages/OnboardingPage.tsx
+++ b/control-plane/frontend/src/pages/OnboardingPage.tsx
@@ -1,0 +1,391 @@
+import { useState, type FormEvent } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
+import { Check, Plus, Pencil, Eye, EyeOff } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { setupCreateAdmin } from "@/api/auth";
+import { useProviders, useCatalogIconMap } from "@/hooks/useProviders";
+import { useUpdateSettings } from "@/hooks/useSettings";
+import ProviderModal from "@/components/ProviderModal";
+import ProviderIcon from "@/components/ProviderIcon";
+import { getNetworkOrServerError } from "@/utils/http";
+import { errorToast } from "@/utils/toast";
+import type { LLMProvider } from "@/types/instance";
+
+type Step = 1 | 2 | 3;
+
+function getSetupError(error: unknown): string {
+  const networkOrServer = getNetworkOrServerError(error);
+  if (networkOrServer) return networkOrServer;
+  if (isAxiosError(error)) {
+    const detail = error.response?.data?.detail;
+    if (typeof detail === "string") return detail;
+  }
+  return "Failed to create admin account";
+}
+
+export default function OnboardingPage() {
+  const [step, setStep] = useState<Step>(1);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4 py-8">
+      <div className="w-full max-w-xl">
+        <div className="mb-6 text-center">
+          <h1 className="text-2xl font-semibold text-gray-900">Welcome to Claworc</h1>
+          <p className="text-sm text-gray-500 mt-1">Let's get you set up. This takes about a minute.</p>
+        </div>
+
+        <Stepper step={step} />
+
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+          {step === 1 && <AdminStep onDone={() => setStep(2)} />}
+          {step === 2 && <ProvidersStep onDone={() => setStep(3)} />}
+          {step === 3 && <TrackingStep />}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Stepper({ step }: { step: Step }) {
+  const labels = ["Admin account", "API keys", "Analytics"];
+  return (
+    <div className="flex items-center justify-center gap-2 mb-6">
+      {labels.map((label, i) => {
+        const n = (i + 1) as Step;
+        const done = step > n;
+        const active = step === n;
+        return (
+          <div key={label} className="flex items-center gap-2">
+            <div
+              className={`w-7 h-7 rounded-full flex items-center justify-center text-xs font-medium border ${
+                done
+                  ? "bg-blue-600 border-blue-600 text-white"
+                  : active
+                    ? "bg-white border-blue-600 text-blue-700"
+                    : "bg-white border-gray-300 text-gray-400"
+              }`}
+            >
+              {done ? <Check size={14} /> : n}
+            </div>
+            <span
+              className={`text-xs ${active ? "text-gray-900 font-medium" : "text-gray-500"}`}
+            >
+              {label}
+            </span>
+            {n < 3 && <div className="w-6 h-px bg-gray-300 mx-1" />}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------- Step 1: Admin ----------
+
+function AdminStep({ onDone }: { onDone: () => void }) {
+  const { refetch } = useAuth();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError("");
+    if (password !== confirmPassword) {
+      setError("Passwords do not match");
+      return;
+    }
+    setLoading(true);
+    try {
+      await setupCreateAdmin({ username, password });
+      refetch();
+      onDone();
+    } catch (err) {
+      setError(getSetupError(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div>
+        <h2 className="text-base font-semibold text-gray-900">Create admin account</h2>
+        <p className="text-sm text-gray-500">You'll use this account to sign in and manage Claworc.</p>
+      </div>
+
+      {error && (
+        <div data-testid="onboarding-error" className="p-3 text-sm text-red-700 bg-red-50 border border-red-200 rounded-md">
+          {error}
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Username</label>
+        <input
+          data-testid="onboarding-username"
+          type="text"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+          autoFocus
+          autoComplete="username"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
+        <input
+          data-testid="onboarding-password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+          autoComplete="new-password"
+        />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">Confirm password</label>
+        <input
+          data-testid="onboarding-confirm-password"
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          required
+          autoComplete="new-password"
+        />
+      </div>
+
+      <div className="flex justify-end pt-2">
+        <button
+          type="submit"
+          disabled={loading}
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? "Creating..." : "Continue"}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ---------- Step 2: LLM Providers + Brave key ----------
+
+function ProvidersStep({ onDone }: { onDone: () => void }) {
+  const queryClient = useQueryClient();
+  const { data: providers = [] } = useProviders();
+  const catalogIconMap = useCatalogIconMap();
+  const updateMutation = useUpdateSettings();
+
+  const [modalOpen, setModalOpen] = useState(false);
+  const [modalMode, setModalMode] = useState<"create" | "edit">("create");
+  const [modalProvider, setModalProvider] = useState<LLMProvider | null>(null);
+  const [braveKey, setBraveKey] = useState("");
+  const [showBrave, setShowBrave] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const openCreate = () => {
+    setModalMode("create");
+    setModalProvider(null);
+    setModalOpen(true);
+  };
+  const openEdit = (p: LLMProvider) => {
+    setModalMode("edit");
+    setModalProvider(p);
+    setModalOpen(true);
+  };
+
+  const handleContinue = async () => {
+    if (!braveKey.trim()) {
+      onDone();
+      return;
+    }
+    setSaving(true);
+    try {
+      await updateMutation.mutateAsync({ brave_api_key: braveKey.trim() });
+      onDone();
+    } catch {
+      // toast handled by hook
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-base font-semibold text-gray-900">Add API keys</h2>
+        <p className="text-sm text-gray-500">
+          Configure at least one LLM provider so instances could use it. You can skip and add them later in Settings
+        </p>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-2">
+          <h3 className="text-sm font-medium text-gray-900">LLM Providers</h3>
+          <button
+            type="button"
+            onClick={openCreate}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            <Plus size={12} />
+            Add Provider
+          </button>
+        </div>
+        {providers.length === 0 ? (
+          <p className="text-sm text-gray-400 italic px-3 py-4 border border-dashed border-gray-200 rounded-md text-center">
+            No providers configured yet.
+          </p>
+        ) : (
+          <div className="border border-gray-200 rounded-md divide-y divide-gray-100">
+            {providers.map((p) => (
+              <div key={p.id} className="flex items-center gap-3 px-3 py-2">
+                <div className="shrink-0 w-6 h-6 flex items-center justify-center">
+                  {p.provider ? (
+                    <ProviderIcon provider={catalogIconMap[p.provider] ?? p.provider} size={22} />
+                  ) : (
+                    <span className="w-6 h-6 rounded-full bg-gray-100 flex items-center justify-center text-xs font-medium text-gray-500">
+                      {p.name[0].toUpperCase()}
+                    </span>
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium text-gray-900 truncate">{p.name}</div>
+                  <div className="text-xs text-gray-400 truncate">
+                    API key: <span className="font-mono">{p.masked_api_key || "not set"}</span>
+                  </div>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => openEdit(p)}
+                  className="shrink-0 p-1 text-gray-400 hover:text-gray-600"
+                  title="Edit provider"
+                >
+                  <Pencil size={14} />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-gray-900 mb-1">Brave API Key</h3>
+        <p className="text-xs text-gray-500 mb-2">Optional. Used for web search (not an LLM provider).</p>
+        <div className="relative">
+          <input
+            type={showBrave ? "text" : "password"}
+            value={braveKey}
+            onChange={(e) => setBraveKey(e.target.value)}
+            placeholder="Leave empty to skip"
+            className="w-full px-3 py-2 pr-10 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <button
+            type="button"
+            onClick={() => setShowBrave((v) => !v)}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+          >
+            {showBrave ? <EyeOff size={14} /> : <Eye size={14} />}
+          </button>
+        </div>
+      </div>
+
+      <div className="flex justify-end pt-2">
+        <button
+          type="button"
+          onClick={handleContinue}
+          disabled={saving}
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
+        >
+          {saving ? "Saving..." : "Continue"}
+        </button>
+      </div>
+
+      <ProviderModal
+        open={modalOpen}
+        mode={modalMode}
+        provider={modalProvider ?? undefined}
+        existingKeys={providers.map((p) => p.key)}
+        onClose={() => setModalOpen(false)}
+        onSaved={() => {
+          queryClient.invalidateQueries({ queryKey: ["llm-providers"] });
+        }}
+      />
+    </div>
+  );
+}
+
+// ---------- Step 3: Tracking consent ----------
+
+function TrackingStep() {
+  const updateMutation = useUpdateSettings();
+  const [shareStats, setShareStats] = useState(true);
+  const [finishing, setFinishing] = useState(false);
+  const { refetch } = useAuth();
+
+  const handleFinish = async () => {
+    setFinishing(true);
+    try {
+      await updateMutation.mutateAsync({
+        analytics_consent: shareStats ? "opt_in" : "opt_out",
+      });
+      // Trigger re-render at app level so setup-required guard re-evaluates.
+      refetch();
+      // Hard navigate to / so the app re-mounts cleanly with auth + settings fresh.
+      window.location.assign("/");
+    } catch (err) {
+      errorToast("Failed to save preference", err);
+      setFinishing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      <div>
+        <h2 className="text-base font-semibold text-gray-900">Anonymous analytics</h2>
+        <p className="text-sm text-gray-500 mt-1">
+          Help us improve Claworc by sharing anonymous usage statistics. We never collect API keys,
+          env-var values, file paths, or instance names. See{" "}
+          <a
+            href="https://claworc.com/docs/analytics"
+            className="text-blue-600 hover:underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            what's collected
+          </a>
+          .
+        </p>
+      </div>
+
+      <label className="flex items-start gap-3 p-3 border border-gray-200 rounded-md cursor-pointer hover:bg-gray-50">
+        <input
+          type="checkbox"
+          checked={shareStats}
+          onChange={(e) => setShareStats(e.target.checked)}
+          className="mt-0.5 h-4 w-4 text-blue-600 rounded border-gray-300"
+        />
+        <div className="text-sm">
+          <div className="font-medium text-gray-900">Share anonymous usage statistics</div>
+          <div className="text-xs text-gray-500 mt-0.5">You can change this anytime in Settings.</div>
+        </div>
+      </label>
+
+      <div className="flex justify-end pt-2">
+        <button
+          type="button"
+          onClick={handleFinish}
+          disabled={finishing}
+          className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
+        >
+          {finishing ? "Finishing..." : "Finish setup"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/control-plane/internal/moderator/dispatcher.go
+++ b/control-plane/internal/moderator/dispatcher.go
@@ -25,6 +25,27 @@ func (s *Service) Dispatch(ctx context.Context, taskID uint) error {
 		return fmt.Errorf("board %d has no eligible instances", board.ID)
 	}
 
+	// Drop ids that no longer correspond to a live instance row — the board's
+	// EligibleInstances JSON can lag behind instance deletion.
+	liveIDs, err := s.opts.Instances.ListInstanceIDs(ctx)
+	if err != nil {
+		return fmt.Errorf("list instances: %w", err)
+	}
+	live := make(map[uint]struct{}, len(liveIDs))
+	for _, id := range liveIDs {
+		live[id] = struct{}{}
+	}
+	filtered := board.EligibleInstances[:0:0]
+	for _, id := range board.EligibleInstances {
+		if _, ok := live[id]; ok {
+			filtered = append(filtered, id)
+		}
+	}
+	board.EligibleInstances = filtered
+	if len(board.EligibleInstances) == 0 {
+		return fmt.Errorf("board %d has no eligible instances", board.ID)
+	}
+
 	souls, err := s.opts.Store.GetSouls(ctx, board.EligibleInstances)
 	if err != nil {
 		return fmt.Errorf("load souls: %w", err)

--- a/install.ps1
+++ b/install.ps1
@@ -179,27 +179,10 @@ function Install-Docker {
         --restart unless-stopped `
         "${DashboardImage}:${Tag}" | Out-Null
 
-    # --- Initial Admin Setup -------------------------------------------------
-
-    Write-Host ""
-    Write-Host "--- Initial Admin Setup ---"
-    $adminUser = Prompt-Value -PromptText "Admin username" -Default "admin"
-
-    while ($true) {
-        $adminPass = Prompt-SecureValue -PromptText "Admin password"
-        $adminPassConfirm = Prompt-SecureValue -PromptText "Confirm password"
-
-        if (($adminPass -eq $adminPassConfirm) -and (-not [string]::IsNullOrWhiteSpace($adminPass))) {
-            break
-        }
-        Write-Host "Passwords do not match or are empty. Try again."
-    }
-
-    Write-Host "Creating admin user..."
-    docker exec $ContainerName /app/claworc --create-admin --username $adminUser --password $adminPass
-
     Write-Host ""
     Write-Host "=== Claworc is running ==="
+    Write-Host ""
+    Write-Host "  Open http://localhost:$port in your browser to finish setup."
     Write-Host ""
     Write-Host "  Dashboard:  http://localhost:$port"
     Write-Host "  Container:  $ContainerName"
@@ -334,27 +317,10 @@ function Install-Kubernetes {
     Write-Host "Waiting for pod to be ready..."
     kubectl wait --for=condition=ready pod -l app=claworc -n $namespace --kubeconfig $kubeconfigPath --timeout=120s 2>$null
 
-    # --- Initial Admin Setup -------------------------------------------------
-
-    Write-Host ""
-    Write-Host "--- Initial Admin Setup ---"
-    $adminUser = Prompt-Value -PromptText "Admin username" -Default "admin"
-
-    while ($true) {
-        $adminPass = Prompt-SecureValue -PromptText "Admin password"
-        $adminPassConfirm = Prompt-SecureValue -PromptText "Confirm password"
-
-        if (($adminPass -eq $adminPassConfirm) -and (-not [string]::IsNullOrWhiteSpace($adminPass))) {
-            break
-        }
-        Write-Host "Passwords do not match or are empty. Try again."
-    }
-
-    Write-Host "Creating admin user..."
-    kubectl exec deploy/claworc -n $namespace --kubeconfig $kubeconfigPath -- /app/claworc --create-admin --username $adminUser --password $adminPass
-
     Write-Host ""
     Write-Host "=== Claworc deployed to Kubernetes ==="
+    Write-Host ""
+    Write-Host "  Open the dashboard URL below in your browser to finish setup."
     Write-Host ""
     if ($serviceType -eq "NodePort") {
         Write-Host "  Dashboard:  http://<node-ip>:$nodePort"

--- a/install.sh
+++ b/install.sh
@@ -118,32 +118,10 @@ install_docker() {
         --restart unless-stopped \
         "$DASHBOARD_IMAGE:$TAG" >/dev/null
 
-    # --- Initial Admin Setup -------------------------------------------------
-
-    echo ""
-    echo "--- Initial Admin Setup ---"
-    printf "Admin username [admin]: "
-    read -r ADMIN_USER </dev/tty
-    ADMIN_USER="${ADMIN_USER:-admin}"
-
-    while true; do
-        printf "Admin password: "
-        read -rs ADMIN_PASS </dev/tty
-        echo
-        printf "Confirm password: "
-        read -rs ADMIN_PASS_CONFIRM </dev/tty
-        echo
-        if [ "$ADMIN_PASS" = "$ADMIN_PASS_CONFIRM" ] && [ -n "$ADMIN_PASS" ]; then
-            break
-        fi
-        echo "Passwords do not match or are empty. Try again."
-    done
-
-    echo "Creating admin user..."
-    docker exec "$CONTAINER_NAME" /app/claworc --create-admin --username "$ADMIN_USER" --password "$ADMIN_PASS"
-
     echo ""
     echo "=== Claworc is running ==="
+    echo ""
+    echo "  Open http://localhost:$PORT in your browser to finish setup."
     echo ""
     echo "  Dashboard:  http://localhost:$PORT"
     echo "  Container:  $CONTAINER_NAME"
@@ -267,32 +245,10 @@ install_kubernetes() {
     echo "Waiting for pod to be ready..."
     kubectl wait --for=condition=ready pod -l app=claworc -n "$NAMESPACE" --kubeconfig "$KUBECONFIG_PATH" --timeout=120s 2>/dev/null || true
 
-    # --- Initial Admin Setup -------------------------------------------------
-
-    echo ""
-    echo "--- Initial Admin Setup ---"
-    printf "Admin username [admin]: "
-    read -r ADMIN_USER </dev/tty
-    ADMIN_USER="${ADMIN_USER:-admin}"
-
-    while true; do
-        printf "Admin password: "
-        read -rs ADMIN_PASS </dev/tty
-        echo
-        printf "Confirm password: "
-        read -rs ADMIN_PASS_CONFIRM </dev/tty
-        echo
-        if [ "$ADMIN_PASS" = "$ADMIN_PASS_CONFIRM" ] && [ -n "$ADMIN_PASS" ]; then
-            break
-        fi
-        echo "Passwords do not match or are empty. Try again."
-    done
-
-    echo "Creating admin user..."
-    kubectl exec deploy/claworc -n "$NAMESPACE" --kubeconfig "$KUBECONFIG_PATH" -- /app/claworc --create-admin --username "$ADMIN_USER" --password "$ADMIN_PASS"
-
     echo ""
     echo "=== Claworc deployed to Kubernetes ==="
+    echo ""
+    echo "  Open the dashboard URL below in your browser to finish setup."
     echo ""
     if [[ "$SERVICE_TYPE" == "NodePort" ]]; then
         echo "  Dashboard:  http://<node-ip>:$NODE_PORT"


### PR DESCRIPTION
## Summary

- New in-browser 3-step onboarding wizard at `/` for fresh installs: create admin account, configure LLM providers (+ optional Brave API key), pick analytics consent
- App gates the entire route tree on `GET /auth/setup-required`; while setup is required all routes redirect to the wizard
- `install.sh` / `install.ps1` no longer prompt for admin credentials or shell into the container to run `--create-admin` — they just point the user to the dashboard URL
- Unrelated fix: moderator dispatcher now filters out stale instance ids from `board.EligibleInstances` before dispatch, so deleted instances don't break a run
- Minor: `make migration` now invokes the `migration-author` agent via `--agent` instead of by reading the agent file inline

No backend changes are required — `POST /auth/setup` already issues a session cookie, so the wizard's later admin-only calls are authenticated.

## Test plan

- [ ] Fresh install (Docker): installer completes without prompting for admin credentials; opening the dashboard URL shows the wizard at `/`
- [ ] Wizard step 1 creates the admin and session; steps 2 and 3 succeed without re-login
- [ ] Existing installs (admin already present): `/auth/setup-required` returns false and the app renders normally
- [ ] Login page still works after the `setupMode` branch was removed
- [ ] Moderator dispatch no longer fails when a board lists a deleted instance id