### PR TITLE
fix: propagate vision capability to OpenClaw instances and add UI indicators

### DIFF
--- a/control-plane/frontend/src/components/ProviderModal.tsx
+++ b/control-plane/frontend/src/components/ProviderModal.tsx
@@ -69,6 +69,7 @@ export default function ProviderModal({
     id: "",
     name: "",
     reasoning: false,
+    vision: false,
     contextWindow: "",
     maxTokens: "",
     costInput: "",
@@ -121,7 +122,7 @@ export default function ProviderModal({
       setMShowApiKey(false);
       setMApiType("openai-completions");
       setMModels([]);
-      setMModelDraft({ id: "", name: "", reasoning: false, contextWindow: "", maxTokens: "", costInput: "", costOutput: "" });
+      setMModelDraft({ id: "", name: "", reasoning: false, vision: false, contextWindow: "", maxTokens: "", costInput: "", costOutput: "" });
       setMShowOptionalFields(false);
     } else if (provider) {
       setMCatalogKey("");
@@ -131,7 +132,7 @@ export default function ProviderModal({
       setMShowApiKey(false);
       setMApiType(provider.api_type || "openai-completions");
       setMModels(provider.models || []);
-      setMModelDraft({ id: "", name: "", reasoning: false, contextWindow: "", maxTokens: "", costInput: "", costOutput: "" });
+      setMModelDraft({ id: "", name: "", reasoning: false, vision: false, contextWindow: "", maxTokens: "", costInput: "", costOutput: "" });
       setMShowOptionalFields(false);
     }
   }, [open, mode, provider]);
@@ -390,6 +391,7 @@ export default function ProviderModal({
     if (!mModelDraft.id.trim() || !mModelDraft.name.trim()) return;
     const model: ProviderModel = { id: mModelDraft.id.trim(), name: mModelDraft.name.trim() };
     if (mModelDraft.reasoning) model.reasoning = true;
+    if (mModelDraft.vision) model.input = ["text", "image"];
     if (mModelDraft.contextWindow) model.contextWindow = parseInt(mModelDraft.contextWindow, 10);
     if (mModelDraft.maxTokens) model.maxTokens = parseInt(mModelDraft.maxTokens, 10);
     const hasInputCost = !!mModelDraft.costInput;
@@ -403,7 +405,7 @@ export default function ProviderModal({
       };
     }
     setMModels((prev) => [...prev, model]);
-    setMModelDraft({ id: "", name: "", reasoning: false, contextWindow: "", maxTokens: "", costInput: "", costOutput: "" });
+    setMModelDraft({ id: "", name: "", reasoning: false, vision: false, contextWindow: "", maxTokens: "", costInput: "", costOutput: "" });
     setMShowOptionalFields(false);
   };
 
@@ -543,6 +545,12 @@ export default function ProviderModal({
                       <div key={i} className="flex items-center justify-between px-2 py-1.5 bg-gray-50 border border-gray-200 rounded text-xs">
                         <span className="font-mono text-gray-700">{m.id}</span>
                         <span className="text-gray-500 mx-2 truncate">{m.name}</span>
+                        {m.input?.includes("image") && (
+                          <span className="inline-flex items-center gap-0.5 text-gray-600 bg-gray-100 px-1.5 py-0.5 rounded text-[10px] font-medium mr-1">
+                            <Eye className="w-3 h-3" />
+                            vision
+                          </span>
+                        )}
                         <button
                           type="button"
                           onClick={() => setMModels((prev) => prev.filter((_, idx) => idx !== i))}
@@ -582,7 +590,7 @@ export default function ProviderModal({
                     onClick={() => setMShowOptionalFields((v) => !v)}
                     className="text-xs text-gray-400 hover:text-gray-600"
                   >
-                    {mShowOptionalFields ? "Hide optional fields" : "Optional fields (reasoning, context window, cost...)"}
+                    {mShowOptionalFields ? "Hide optional fields" : "Optional fields (reasoning, vision, context window, cost...)"}
                   </button>
                   {mShowOptionalFields && (
                     <div className="space-y-2 pt-1">
@@ -593,6 +601,14 @@ export default function ProviderModal({
                           onChange={(e) => setMModelDraft((d) => ({ ...d, reasoning: e.target.checked }))}
                         />
                         Reasoning model
+                      </label>
+                      <label className="flex items-center gap-2 text-xs text-gray-600 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={mModelDraft.vision}
+                          onChange={(e) => setMModelDraft((d) => ({ ...d, vision: e.target.checked }))}
+                        />
+                        Vision (image support)
                       </label>
                       <div className="grid grid-cols-2 gap-2">
                         <div>

--- a/control-plane/frontend/src/components/ProviderModelSelector.tsx
+++ b/control-plane/frontend/src/components/ProviderModelSelector.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, Eye } from "lucide-react";
 import ProviderIcon from "@/components/ProviderIcon";
 import type { LLMProvider } from "@/types/instance";
 import type { CatalogProviderDetail } from "@/api/llm";
@@ -19,6 +19,7 @@ interface ModelEntry {
   name: string;
   tag?: string | null;
   description?: string | null;
+  vision?: boolean;
 }
 
 const TAG_STYLES: Record<string, string> = {
@@ -126,12 +127,13 @@ export default function ProviderModelSelector({
         const isDynamic = !p.provider && !isCustom;
 
         const availableModels: ModelEntry[] = isCustom
-          ? (p.models ?? []).map((m) => ({ id: m.id, name: m.name }))
+          ? (p.models ?? []).map((m) => ({ id: m.id, name: m.name, vision: m.input?.includes("image") }))
           : (catalogDetail?.models ?? []).map((m) => ({
               id: m.model_id,
               name: m.model_name,
               tag: m.tag,
               description: m.description,
+              vision: m.vision,
             }));
 
         const selectedModels = providerModels[p.id] ?? [];
@@ -248,6 +250,12 @@ export default function ProviderModelSelector({
                                   {m.tag}
                                 </span>
                               )}
+                              {m.vision && (
+                                <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs font-medium rounded bg-gray-100 text-gray-600">
+                                  <Eye size={10} />
+                                  vision
+                                </span>
+                              )}
                             </div>
                             {m.description && (
                               <div className="text-xs text-gray-500 mt-0.5">{m.description}</div>
@@ -268,7 +276,7 @@ export default function ProviderModelSelector({
       {/* Instance-specific providers (always enabled, model selection only) */}
       {instanceProviders.map((p) => {
         const isOpen = expanded.has(p.id);
-        const availableModels: ModelEntry[] = (p.models ?? []).map((m) => ({ id: m.id, name: m.name }));
+        const availableModels: ModelEntry[] = (p.models ?? []).map((m) => ({ id: m.id, name: m.name, vision: m.input?.includes("image") }));
         const selectedModels = providerModels[p.id] ?? [];
         const iconKey = p.provider ? catalogDetailMap[p.provider]?.icon_key ?? undefined : undefined;
 
@@ -329,7 +337,15 @@ export default function ProviderModelSelector({
                       className="mt-0.5"
                     />
                     <div className="min-w-0 flex-1">
-                      <span className="text-sm text-gray-900">{m.name}</span>
+                      <div className="flex items-center gap-2">
+                        <span className="text-sm text-gray-900">{m.name}</span>
+                        {m.vision && (
+                          <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs font-medium rounded bg-gray-100 text-gray-600">
+                            <Eye size={10} />
+                            vision
+                          </span>
+                        )}
+                      </div>
                     </div>
                     <span className="text-xs font-mono text-gray-400 shrink-0 mt-0.5">{m.id}</span>
                   </label>

--- a/control-plane/frontend/src/pages/InstanceDetailPage.tsx
+++ b/control-plane/frontend/src/pages/InstanceDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, createElement } from "react";
 import { Link, useParams, useNavigate, useLocation } from "react-router-dom";
-import { AlertTriangle, X, Maximize, ExternalLink, Plus } from "lucide-react";
+import { AlertTriangle, Eye, X, Maximize, ExternalLink, Plus } from "lucide-react";
 import { useAuth } from "@/contexts/AuthContext";
 import { useTeam } from "@/contexts/TeamContext";
 import StatusBadge from "@/components/StatusBadge";
@@ -402,6 +402,7 @@ export default function InstanceDetailPage() {
     const displayModels: string[] = (instance.models.extra ?? [])
       .filter((m) => m.startsWith(`${p.key}/`))
       .map((m) => m.slice(`${p.key}/`.length));
+    const visionModels = new Set((p.models ?? []).filter((m) => m.input?.includes("image")).map((m) => m.id));
     return (
       <div key={`${isInstanceProvider ? "inst" : "global"}-${p.id}`} className="bg-white rounded-lg border border-gray-200 px-4 py-3">
         <div className="flex items-center gap-3">
@@ -436,9 +437,10 @@ export default function InstanceDetailPage() {
               return (
                 <span
                   key={m}
-                  className={`px-2 py-0.5 text-xs rounded font-mono ${isPrimary ? "bg-blue-100 text-blue-700 ring-1 ring-blue-300" : "bg-gray-100 text-gray-600"}`}
+                  className={`inline-flex items-center gap-1 px-2 py-0.5 text-xs rounded font-mono ${isPrimary ? "bg-blue-100 text-blue-700 ring-1 ring-blue-300" : "bg-gray-100 text-gray-600"}`}
                 >
                   {m}{isPrimary && <span className="ml-1 font-sans not-italic">★</span>}
+                  {visionModels.has(m) && <Eye size={10} />}
                 </span>
               );
             })}

--- a/control-plane/frontend/src/pages/SettingsPage.tsx
+++ b/control-plane/frontend/src/pages/SettingsPage.tsx
@@ -311,7 +311,7 @@ function ApiKeysTab({
                   ? `Expires in ${formatExpiresIn(p.oauth_expires_at - Date.now())}`
                   : "ChatGPT account not linked"
                 : null;
-              const displayModels = (p.models || []).map((m) => m.id);
+              const displayModels = p.models || [];
               return (
                 <div key={p.id}>
                   <div className="flex items-center py-3 -mx-2 px-2 rounded transition-colors">
@@ -354,9 +354,10 @@ function ApiKeysTab({
                       <p className="text-xs text-gray-400 italic">No models available.</p>
                     ) : (
                       <div className="flex flex-wrap gap-1">
-                        {displayModels.map((id) => (
-                          <span key={id} className="font-mono text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">
-                            {id}
+                        {displayModels.map((m) => (
+                          <span key={m.id} className="inline-flex items-center gap-1 font-mono text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">
+                            {m.id}
+                            {m.input?.includes("image") && <Eye size={10} />}
                           </span>
                         ))}
                       </div>

--- a/control-plane/internal/handlers/providers.go
+++ b/control-plane/internal/handlers/providers.go
@@ -220,6 +220,9 @@ func catalogModelToProviderModel(m catalogRootModel) database.ProviderModel {
 		ContextWindow: m.ContextWindow,
 		MaxTokens:     m.MaxTokens,
 	}
+	if m.Vision {
+		pm.Input = []string{"text", "image"}
+	}
 	if m.InputCost > 0 || m.OutputCost > 0 || m.CachedReadCost > 0 || m.CachedWriteCost > 0 {
 		pm.Cost = &database.ProviderModelCost{
 			Input:      m.InputCost,


### PR DESCRIPTION
## Summary
- **Vision was broken for all providers.** The `ProviderModel.Input` field was never populated by any code path, so every model was pushed to OpenClaw as text-only - including catalog vision models like Claude Sonnet and GPT-4o.
- Fix vision capability not being propagated from the model catalog to OpenClaw instances (`catalogModelToProviderModel` now maps `vision: true` → `input: ["text", "image"]`)
- Add vision indicator (Eye icon) to model displays in Settings > Model API Keys, Instance Detail provider cards, Provider Modal model list, and Provider Model Selector
- Add vision toggle checkbox to the custom model creation form in Provider Modal
