### PR TITLE
fix(agent-tests): adapt to upstream openclaw drift

### DIFF
--- a/agent/tests/__snapshots__/openclaw.test.ts.snap
+++ b/agent/tests/__snapshots__/openclaw.test.ts.snap
@@ -69,9 +69,6 @@ exports[`agent image > openclaw.json structure matches snapshot 1`] = `
       "blucli": {
         "enabled": "boolean",
       },
-      "bluebubbles": {
-        "enabled": "boolean",
-      },
       "camsnap": {
         "enabled": "boolean",
       },

--- a/agent/tests/openclaw.test.ts
+++ b/agent/tests/openclaw.test.ts
@@ -155,24 +155,10 @@ describe.skipIf(!container)("agent image", { timeout: 300_000 }, () => {
 
   // Regression for https://github.com/gluk-w/claworc/issues/127. sharp is a
   // native addon (libvips) used by openclaw's image pipeline (Telegram,
-  // screenshots). It silently went missing when sharp 0.34 switched to
-  // prebuilt binaries that need libvips on the system.
+  // screenshots). Upstream openclaw lazy-imports sharp but no longer
+  // declares it in package.json, so the Dockerfile installs it explicitly.
   describe("sharp image dependency (issue #127)", () => {
     const cdOpenclaw = 'cd "$(npm root -g)/openclaw"';
-
-    it("openclaw still declares sharp as a build dependency", () => {
-      // If upstream openclaw drops sharp, the runtime check below loses its
-      // meaning — surface that change so we can revisit the Dockerfile.
-      // openclaw lists sharp under pnpm's `onlyBuiltDependencies` rather
-      // than `dependencies`/`optional`/`peer`, so check all four locations.
-      const result = exec(container!, [
-        "bash",
-        "-c",
-        `${cdOpenclaw} && node -e "const p=require('./package.json'); const inField=(o)=>o&&(o.sharp||(Array.isArray(o)&&o.includes('sharp'))); const found=inField(p.dependencies)||inField(p.optionalDependencies)||inField(p.peerDependencies)||inField(p.pnpm&&p.pnpm.onlyBuiltDependencies); if(!found){process.exit(2)} console.log('ok')"`,
-      ]);
-      expect(result.exitCode).toBe(0);
-      expect(result.stdout.trim()).toBe("ok");
-    });
 
     it("openclaw can load sharp for image processing", () => {
       // Resolve sharp the same way openclaw does at runtime — from its own


### PR DESCRIPTION
## Summary
- Drop `bluebubbles` from the openclaw.json structure snapshot — upstream openclaw removed the skill from its default config.
- Remove the sentinel test that watched for `sharp` being dropped from openclaw's package.json — it has now fired (upstream no longer declares `sharp` in dependencies / optional / peer / `pnpm.onlyBuiltDependencies`) and served its purpose. The remaining runtime test (`openclaw can load sharp for image processing`) continues to guard that the Dockerfile's explicit `npm install sharp` workaround keeps working.

Fixes the failing scheduled `Build and Push Agent Image` run: https://github.com/gluk-w/claworc/actions/runs/26027330332

## Test plan
- [ ] Wait for the agent build job to go green on this PR before merging