### PR TITLE
chore(agent): sharp housekeeping — update Dockerfile comment, add upstream-usage sentinel

### DIFF
--- a/agent/instance/Dockerfile
+++ b/agent/instance/Dockerfile
@@ -36,10 +36,13 @@ RUN apt-get update && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && locale-gen && \
     if [ "$USE_CHINA_MIRRORS" = "true" ]; then npm config set registry https://registry.npmmirror.com; fi && \
     npm install -g --legacy-peer-deps openclaw@${OPENCLAW_VERSION} && \
-    # OpenClaw lists `sharp` only under pnpm's `onlyBuiltDependencies`, not
-    # `dependencies`, so `npm install -g openclaw` never installs it. The
-    # image pipeline (Telegram, screenshots) lazy-imports `sharp` at runtime
-    # — without this step it throws ERR_MODULE_NOT_FOUND. See issue #127.
+    # Upstream openclaw doesn't declare `sharp` in its published
+    # package.json at all (neither dependencies, optionalDependencies,
+    # peerDependencies, nor pnpm.onlyBuiltDependencies), but the image
+    # pipeline (Telegram, screenshots) still lazy-imports it at runtime on
+    # Linux via src/media/image-ops.ts — without this step it throws
+    # ERR_MODULE_NOT_FOUND. See issue #127. The agent-test suite's
+    # "openclaw can load sharp for image processing" check guards this.
     (cd "$(npm root -g)/openclaw" && npm install --no-save --legacy-peer-deps sharp) && \
     curl -sSL https://install.python-poetry.org | POETRY_HOME=/usr/local python3 - && \
     rm -rf /var/lib/apt/lists/*

--- a/agent/tests/openclaw.test.ts
+++ b/agent/tests/openclaw.test.ts
@@ -156,7 +156,9 @@ describe.skipIf(!container)("agent image", { timeout: 300_000 }, () => {
   // Regression for https://github.com/gluk-w/claworc/issues/127. sharp is a
   // native addon (libvips) used by openclaw's image pipeline (Telegram,
   // screenshots). Upstream openclaw lazy-imports sharp but no longer
-  // declares it in package.json, so the Dockerfile installs it explicitly.
+  // declares it in package.json, so the Dockerfile installs it explicitly
+  // (see `npm install --no-save sharp` in agent/instance/Dockerfile, plus
+  // the libvips42 apt package).
   describe("sharp image dependency (issue #127)", () => {
     const cdOpenclaw = 'cd "$(npm root -g)/openclaw"';
 
@@ -171,6 +173,20 @@ describe.skipIf(!container)("agent image", { timeout: 300_000 }, () => {
       ]);
       expect(result.exitCode).toBe(0);
       expect(result.stdout.trim()).toMatch(/^\d+\.\d+\.\d+/);
+    });
+
+    it("openclaw runtime still references sharp", () => {
+      // If upstream stops importing sharp, the Dockerfile's explicit
+      // `npm install --no-save sharp` (and the libvips42 apt package) become
+      // dead weight — surface that so we can drop them. We grep the bundled
+      // dist for any `sharp` reference (string literal in dynamic import,
+      // static import, etc).
+      const result = exec(container!, [
+        "bash",
+        "-c",
+        `${cdOpenclaw} && grep -rEq "['\\"]sharp['\\"]" dist`,
+      ]);
+      expect(result.exitCode).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Background
Git blame on the sentinel test removed in #146 (originally added in #129) shows it was put there because openclaw declared \`sharp\` only under \`pnpm.onlyBuiltDependencies\`. The agent installs sharp manually in \`agent/instance/Dockerfile\` (\`npm install --no-save sharp\` + the \`libvips42\` apt package) to fix #127 (Telegram/screenshot image processing).

Today upstream openclaw doesn't declare sharp anywhere in its published \`package.json\`, but \`src/media/image-ops.ts\` still lazy-imports it at runtime on Linux. So our Dockerfile workaround is still needed — only the rationale changed.

## Summary
- Update the Dockerfile comment to reflect that sharp is now completely undeclared upstream (not just hidden under \`onlyBuiltDependencies\`) and cross-reference the test that guards it.
- Replace the dropped package.json sentinel with one asking the *right* question: does the *installed* openclaw still reference sharp? If it stops, the Dockerfile install and \`libvips42\` become dead weight and we should drop them.

## Test plan
- [ ] Wait for the agent build job to confirm the new sentinel passes against current openclaw