### PR TITLE
fix(agent-tests): strip plugins/skills from openclaw config snapshot

### DIFF
--- a/agent/tests/__snapshots__/openclaw.test.ts.snap
+++ b/agent/tests/__snapshots__/openclaw.test.ts.snap
@@ -49,16 +49,6 @@ exports[`agent image > openclaw.json structure matches snapshot 1`] = `
   "session": {
     "dmScope": "string",
   },
-  "skills": {
-    "entries": {
-      "<skill>": {
-        "enabled": "boolean",
-      },
-    },
-    "install": {
-      "nodeManager": "string",
-    },
-  },
   "tools": {
     "profile": "string",
   },

--- a/agent/tests/openclaw.test.ts
+++ b/agent/tests/openclaw.test.ts
@@ -96,13 +96,15 @@ describe.skipIf(!container)("agent image", { timeout: 300_000 }, () => {
     expect(result.exitCode).toBe(0);
 
     const config = JSON.parse(result.stdout);
-    // Upstream openclaw adds/removes built-in skills frequently. Collapse
-    // the dynamic `skills.entries` map to a single representative shape so
-    // the snapshot tracks the schema, not the changing skill catalog.
-    if (config?.skills?.entries && typeof config.skills.entries === "object") {
-      const sample = Object.values(config.skills.entries)[0] ?? {};
-      config.skills.entries = { "<skill>": sample };
-    }
+    // Strip upstream-owned plugin/skill catalogs entirely. They're not
+    // schema we depend on, they change weekly as openclaw adds/removes
+    // built-ins, and they're shaped completely differently between
+    // `openclaw@latest` (uses `skills.entries.*`) and `openclaw@stable`
+    // (uses `plugins.entries.*`) — so a single snapshot can't track both.
+    // The stable parts of the config (gateway, browser, agents, meta, ...)
+    // are what our integration actually cares about.
+    delete config.skills;
+    delete config.plugins;
     expect(structureOf(config)).toMatchSnapshot();
   });
 


### PR DESCRIPTION
## Summary
Scheduled main run https://github.com/gluk-w/claworc/actions/runs/26116391360 failed at the *stable* openclaw image step (the workflow tests both latest and stable). Stable openclaw uses a completely different schema for built-in extensions (\`plugins.entries.*\`) than latest (\`skills.entries.*\`), so one snapshot can't track both — and #147's skills-only collapse didn't help because stable has no \`skills.entries\` at all.

These upstream-owned catalogs aren't schema we depend on and change weekly. Drop both \`skills\` and \`plugins\` from the snapshot entirely so the test focuses on the parts of openclaw.json our integration actually cares about (gateway, browser, agents, meta, ...).

## Test plan
- [ ] Confirm agent build CI goes green on both latest and stable image steps