### PR TITLE
security: fix code scanning alerts

### DIFF
--- a/control-plane/internal/handlers/webhook_trigger.go
+++ b/control-plane/internal/handlers/webhook_trigger.go
@@ -262,7 +262,7 @@ func runWebhookRequest(w http.ResponseWriter, r *http.Request, isPrivate bool) {
 	if err != nil {
 		logRow.StatusCode = http.StatusBadGateway
 		logRow.ErrorMessage = err.Error()
-		log.Printf("[webhook] instance=%d session=%s bridge error: %v", inst.ID, utils.SanitizeForLog(call.SessionName), err)
+		log.Printf("[webhook] instance=%d session=%s bridge error: %s", inst.ID, utils.SanitizeForLog(call.SessionName), utils.SanitizeForLog(err.Error()))
 		http.Error(w, "agent error: "+err.Error(), http.StatusBadGateway)
 		return
 	}


### PR DESCRIPTION
## Summary

- **Alert #448 (go/log-injection, medium)** — `webhook_trigger.go` line 265: the error value returned by `runWebhookBridge` can reflect user-controlled content (the webhook message or session name echoed back in the bridge error). The session name was already sanitized, but `err` was logged raw with `%v`. Fixed by applying `utils.SanitizeForLog(err.Error())` to strip newlines and control characters before the value reaches the log sink.

## Alerts not in scope

- **Alerts #449, #450 (js/unused-local-variable, note severity)** — TypeScript unused-variable notices with null security severity. Excluded per the medium/high/critical scope agreed for this sweep.

## Verification

- `go build ./internal/... ./cmd/...` — clean
- `go test ./internal/handlers/... ./internal/utils/...` — all pass
- Pre-existing `go vet` warnings in test files are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)