### PR TITLE
fix: cap provider model list height on settings pages (#90)

### DIFF
--- a/control-plane/frontend/src/app/pages/SettingsPage.tsx
+++ b/control-plane/frontend/src/app/pages/SettingsPage.tsx
@@ -246,6 +246,15 @@ function ApiKeysTab({
   const [editingBrave, setEditingBrave] = useState(false);
   const [braveValue, setBraveValue] = useState("");
   const [showBrave, setShowBrave] = useState(false);
+  const [expandedModels, setExpandedModels] = useState<Set<number>>(new Set());
+  const toggleExpandedModels = (id: number) => {
+    setExpandedModels((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
 
   const syncMutation = useMutation({
     mutationFn: syncAllProviders,
@@ -351,16 +360,33 @@ function ApiKeysTab({
                   <div className="pb-3 px-2">
                     {displayModels.length === 0 ? (
                       <p className="text-xs text-gray-400 italic">No models available.</p>
-                    ) : (
-                      <div className="flex flex-wrap gap-1">
-                        {displayModels.map((m) => (
-                          <span key={m.id} className="inline-flex items-center gap-1 font-mono text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">
-                            {m.id}
-                            {m.input?.includes("image") && <Eye size={10} />}
-                          </span>
-                        ))}
-                      </div>
-                    )}
+                    ) : (() => {
+                      const isExpanded = expandedModels.has(p.id);
+                      const collapsible = displayModels.length > 10;
+                      return (
+                        <>
+                          <div
+                            className={`flex flex-wrap gap-1 ${collapsible && !isExpanded ? "max-h-[4.75rem] overflow-hidden" : ""}`}
+                          >
+                            {displayModels.map((m) => (
+                              <span key={m.id} className="inline-flex items-center gap-1 font-mono text-xs bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded">
+                                {m.id}
+                                {m.input?.includes("image") && <Eye size={10} />}
+                              </span>
+                            ))}
+                          </div>
+                          {collapsible && (
+                            <button
+                              type="button"
+                              onClick={() => toggleExpandedModels(p.id)}
+                              className="mt-1 text-xs text-blue-600 hover:text-blue-800"
+                            >
+                              {isExpanded ? "Show less" : `... show all (${displayModels.length})`}
+                            </button>
+                          )}
+                        </>
+                      );
+                    })()}
                   </div>
                 </div>
               );

--- a/control-plane/frontend/src/common/components/ProviderModelSelector.tsx
+++ b/control-plane/frontend/src/common/components/ProviderModelSelector.tsx
@@ -226,7 +226,7 @@ export default function ProviderModelSelector({
                     {p.provider && !catalogDetail ? "Loading models..." : "No models available."}
                   </div>
                 ) : (
-                  <div className="divide-y divide-gray-100">
+                  <div className="divide-y divide-gray-100 max-h-96 overflow-y-auto">
                     {availableModels.map((m) => {
                       const checked = selectedModels.includes(m.id);
                       return (
@@ -324,6 +324,7 @@ export default function ProviderModelSelector({
                     Deselect all
                   </button>
                 </div>
+                <div className="max-h-80 overflow-y-auto space-y-1">
                 {availableModels.map((m) => (
                   <label key={m.id} className="flex items-start gap-3 py-1.5 px-2 rounded hover:bg-amber-50 cursor-pointer">
                     <input
@@ -350,6 +351,7 @@ export default function ProviderModelSelector({
                     <span className="text-xs font-mono text-gray-400 shrink-0 mt-0.5">{m.id}</span>
                   </label>
                 ))}
+                </div>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Summary

- OpenRouter exposes ~357 models, causing the provider model lists on `/settings` and the per-instance settings page to overflow the page and push action buttons offscreen.
- Cap per-provider model lists on the instance settings page (`ProviderModelSelector`) at ~10 visible rows with internal scroll.
- On the global `SettingsPage`, clamp each provider's model badge list to ~3 rows when there are >10 models, with a `... show all (N)` / `Show less` toggle.

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)