### PR TITLE
feat: host-backed shared folders (#156)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Local development files
+.air
 .env
 !.env.development
 data/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ Backend settings use `envconfig` with `CLAWORC_` env prefix (see `internal/confi
 - `CLAWORC_TERMINAL_HISTORY_LINES` - Scrollback buffer size in lines (default: `1000`, `0` to disable)
 - `CLAWORC_TERMINAL_RECORDING_DIR` - Directory for audit recordings (default: empty, disabled)
 - `CLAWORC_TERMINAL_SESSION_TIMEOUT` - Idle detached session timeout (default: `30m`)
+- `CLAWORC_ALLOWED_HOST_MOUNTS` - Comma-separated allowlist of host path prefixes within which shared folders may be backed by a host bind mount. Empty (default) disables host-backed shared folders entirely. See `docs/shared-folders.md`.
 
 ## Terminology
 

--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ dev:
 	@echo "Control plane: http://localhost:8000"
 	@echo "Frontend:      http://localhost:5173"
 	@echo ""
-	CLAWORC_AUTH_DISABLED=true CLAWORC_LLM_RESPONSE_LOG=$(CURDIR)/llm-responses.log goreman -set-ports=false start
+	CLAWORC_AUTH_DISABLED=true CLAWORC_LLM_RESPONSE_LOG=$(CURDIR)/llm-responses.log CLAWORC_ALLOWED_HOST_MOUNTS=/tmp,~/ goreman -set-ports=false start
 
 ssh-integration-test:
 	docker build -f agent/instance/Dockerfile -t claworc-agent:local agent/instance/

--- a/control-plane/frontend/src/app/pages/SharedFoldersPage.tsx
+++ b/control-plane/frontend/src/app/pages/SharedFoldersPage.tsx
@@ -1,10 +1,17 @@
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { FolderOpen, Trash2, AlertTriangle } from "lucide-react";
+import {
+  FolderOpen,
+  Trash2,
+  AlertTriangle,
+  ChevronRight,
+  ChevronDown,
+} from "lucide-react";
 import AgentTeamPicker from "@common/components/AgentTeamPicker";
 import { useTeam } from "@common/contexts/TeamContext";
 import {
   fetchSharedFolders,
+  fetchHostMountConfig,
   createSharedFolder,
   updateSharedFolder,
   deleteSharedFolder,
@@ -208,6 +215,11 @@ function FolderModal({
 
   const [name, setName] = useState(folder?.name ?? "");
   const [mountPath, setMountPath] = useState(folder?.mount_path ?? "");
+  const [mountToHost, setMountToHost] = useState(
+    !!folder?.host_path,
+  );
+  const [hostPath, setHostPath] = useState(folder?.host_path ?? "");
+  const [readOnly, setReadOnly] = useState(folder?.read_only ?? true);
   const [selectedInstances, setSelectedInstances] = useState<number[]>(
     folder?.instance_ids ?? [],
   );
@@ -225,6 +237,11 @@ function FolderModal({
     queryFn: fetchSharedFolders,
   });
 
+  const { data: hostMountConfig } = useQuery({
+    queryKey: ["host-mount-config"],
+    queryFn: fetchHostMountConfig,
+  });
+
   const trimmedMountPath = mountPath.trim();
   const duplicateMountPath =
     trimmedMountPath !== "" &&
@@ -232,8 +249,25 @@ function FolderModal({
       (f) => f.mount_path === trimmedMountPath && f.id !== folder?.id,
     );
 
+  const trimmedHostPath = hostPath.trim();
+  const allowedPrefixes = hostMountConfig?.allowed_prefixes ?? [];
+  const hostPathWithinAllowlist =
+    trimmedHostPath.startsWith("/") &&
+    !trimmedHostPath.includes("..") &&
+    allowedPrefixes.some(
+      (p) => trimmedHostPath === p || trimmedHostPath.startsWith(p + "/"),
+    );
+  const hostPathInvalid = mountToHost && !hostPathWithinAllowlist;
+
   const createMutation = useMutation({
-    mutationFn: () => createSharedFolder({ name, mount_path: mountPath }),
+    mutationFn: () =>
+      createSharedFolder({
+        name,
+        mount_path: mountPath,
+        ...(mountToHost
+          ? { host_path: trimmedHostPath, read_only: readOnly }
+          : {}),
+      }),
     onSuccess: (created) => {
       // If anything is selected, attach it in a second PUT.
       if (selectedInstances.length > 0 || selectedTeamIds.length > 0) {
@@ -258,6 +292,7 @@ function FolderModal({
         name,
         instance_ids: selectedInstances,
         team_ids: selectedTeamIds,
+        ...(folder?.host_path ? { read_only: readOnly } : {}),
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["shared-folders"] });
@@ -269,7 +304,10 @@ function FolderModal({
 
   const isPending = createMutation.isPending || updateMutation.isPending;
   const canSave =
-    name.trim() !== "" && mountPath.startsWith("/") && !duplicateMountPath;
+    name.trim() !== "" &&
+    mountPath.startsWith("/") &&
+    !duplicateMountPath &&
+    !hostPathInvalid;
 
   const origIds = folder?.instance_ids ?? [];
   const hasInstanceChanges =
@@ -346,6 +384,81 @@ function FolderModal({
               </p>
             )}
           </div>
+
+          {hostMountConfig?.enabled && (
+            <div>
+              <button
+                type="button"
+                onClick={() => !folder && setMountToHost((v) => !v)}
+                disabled={!!folder}
+                aria-expanded={mountToHost}
+                className="flex items-center gap-1.5 text-sm text-gray-700 hover:text-gray-900 disabled:cursor-not-allowed"
+              >
+                {mountToHost ? (
+                  <ChevronDown size={16} className="text-gray-400" />
+                ) : (
+                  <ChevronRight size={16} className="text-gray-400" />
+                )}
+                <span>Mount to Host</span>
+              </button>
+              <p className="text-xs text-gray-400 mt-1">
+                Back this folder with a directory on the host instead of a
+                managed volume.
+              </p>
+
+              {mountToHost && (
+                <div className="mt-3 space-y-3">
+                  <div>
+                    <label className="block text-xs text-gray-500 mb-1">
+                      Host Path
+                    </label>
+                    <input
+                      type="text"
+                      value={hostPath}
+                      onChange={(e) => setHostPath(e.target.value)}
+                      readOnly={!!folder}
+                      className={`w-full px-3 py-1.5 border rounded-md text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500 ${
+                        folder
+                          ? "bg-gray-50 text-gray-500 cursor-not-allowed border-gray-300"
+                          : hostPathInvalid
+                            ? "border-red-300"
+                            : "border-gray-300"
+                      }`}
+                      placeholder="/Users/example/shared/obsidian"
+                    />
+                    {folder ? (
+                      <p className="text-xs text-gray-400 mt-1">
+                        Host path cannot be changed after creation.
+                      </p>
+                    ) : hostPathInvalid ? (
+                      <p className="text-xs text-red-600 mt-1">
+                        Host path must be within an allowed location:{" "}
+                        {allowedPrefixes.join(", ")}
+                      </p>
+                    ) : (
+                      <p className="text-xs text-gray-400 mt-1">
+                        Allowed locations: {allowedPrefixes.join(", ")}
+                      </p>
+                    )}
+                  </div>
+
+                  <div>
+                    <label className="block text-xs text-gray-500 mb-1">
+                      Access Mode
+                    </label>
+                    <select
+                      value={readOnly ? "ro" : "rw"}
+                      onChange={(e) => setReadOnly(e.target.value === "ro")}
+                      className="w-full px-3 py-1.5 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    >
+                      <option value="ro">Read-only</option>
+                      <option value="rw">Read-write</option>
+                    </select>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
 
           <div>
             <label className="block text-xs text-gray-500 mb-1">

--- a/control-plane/frontend/src/common/api/sharedFolders.ts
+++ b/control-plane/frontend/src/common/api/sharedFolders.ts
@@ -4,10 +4,17 @@ export interface SharedFolder {
   id: number;
   name: string;
   mount_path: string;
+  host_path: string;
+  read_only: boolean;
   owner_id: number;
   instance_ids: number[];
   team_ids: number[];
   created_at: string;
+}
+
+export interface HostMountConfig {
+  enabled: boolean;
+  allowed_prefixes: string[];
 }
 
 export async function fetchSharedFolders(): Promise<SharedFolder[]> {
@@ -15,9 +22,16 @@ export async function fetchSharedFolders(): Promise<SharedFolder[]> {
   return res.data;
 }
 
+export async function fetchHostMountConfig(): Promise<HostMountConfig> {
+  const res = await client.get("/shared-folders/host-mount-config");
+  return res.data;
+}
+
 export async function createSharedFolder(data: {
   name: string;
   mount_path: string;
+  host_path?: string;
+  read_only?: boolean;
 }): Promise<SharedFolder> {
   const res = await client.post("/shared-folders", data);
   return res.data;
@@ -33,6 +47,7 @@ export async function updateSharedFolder(
   data: {
     name?: string;
     mount_path?: string;
+    read_only?: boolean;
     instance_ids?: number[];
     team_ids?: number[];
   },

--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -19,6 +19,11 @@ type Settings struct {
 	RPOrigins    []string `envconfig:"RP_ORIGINS" default:"http://localhost:8000"`
 	RPID         string   `envconfig:"RP_ID" default:"localhost"`
 
+	// AllowedHostMounts is the operator-controlled allowlist of host path
+	// prefixes within which shared folders may be backed by a host bind mount.
+	// Empty (the default) disables host-backed shared folders entirely.
+	AllowedHostMounts []string `envconfig:"ALLOWED_HOST_MOUNTS" default:""`
+
 	// Terminal session settings
 	TerminalHistoryLines   int    `envconfig:"TERMINAL_HISTORY_LINES" default:"1000"`
 	TerminalRecordingDir   string `envconfig:"TERMINAL_RECORDING_DIR" default:""`

--- a/control-plane/internal/database/migrations/migration_00008_noop_shared_folder_host_path.go
+++ b/control-plane/internal/database/migrations/migration_00008_noop_shared_folder_host_path.go
@@ -1,0 +1,31 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+// 00008_noop_shared_folder_host_path: registry placeholder for the
+// SharedFolder.HostPath and SharedFolder.ReadOnly columns added for the
+// host-backed shared folders feature.
+//
+// Per docs/migrations.md, additive column changes are handled by
+// AutoMigrateAll on boot and do not require a Goose migration. However,
+// the CI "Migration Drift Check" guard in .github/workflows/control-plane.yml
+// errors out whenever models/models.go changes without a new migration file,
+// so we register a no-op here to satisfy that guard and keep the goose
+// registry contiguous.
+func init() {
+	register(&goose.Migration{
+		Version: 8,
+		Source:  "00008_noop_shared_folder_host_path.go",
+		UpFnContext: func(ctx context.Context, tx *sql.Tx) error {
+			return nil
+		},
+		DownFnContext: func(ctx context.Context, tx *sql.Tx) error {
+			return nil
+		},
+	})
+}

--- a/control-plane/internal/database/models/models.go
+++ b/control-plane/internal/database/models/models.go
@@ -297,8 +297,18 @@ type SharedFolder struct {
 	OwnerID     uint      `gorm:"not null;index" json:"owner_id"`
 	InstanceIDs string    `gorm:"type:text;default:'[]'" json:"-"` // JSON array of uint IDs
 	TeamIDs     string    `gorm:"type:text;default:'[]'" json:"-"` // JSON array of uint team IDs
-	CreatedAt   time.Time `gorm:"autoCreateTime" json:"created_at"`
-	UpdatedAt   time.Time `gorm:"autoUpdateTime" json:"updated_at"`
+	// HostPath, when non-empty, makes this folder a host bind mount backed by
+	// the given host directory instead of a managed volume/PVC. It is gated by
+	// the CLAWORC_ALLOWED_HOST_MOUNTS allowlist and is immutable after creation.
+	HostPath string `gorm:"type:text;default:''" json:"host_path"`
+	// ReadOnly controls whether a host-backed mount is mounted read-only.
+	// Host-backed folders default to read-only (enforced in the create handler).
+	// No GORM `default` tag here on purpose: with one, GORM treats a false value
+	// as "unset" and lets the DB default win, so an explicit read-write choice
+	// would be silently flipped back to read-only on insert.
+	ReadOnly  bool      `json:"read_only"`
+	CreatedAt time.Time `gorm:"autoCreateTime" json:"created_at"`
+	UpdatedAt time.Time `gorm:"autoUpdateTime" json:"updated_at"`
 }
 
 // ParseSharedFolderInstanceIDs deserializes the JSON instance IDs field.

--- a/control-plane/internal/handlers/instances.go
+++ b/control-plane/internal/handlers/instances.go
@@ -680,6 +680,8 @@ func getSharedFolderMounts(instanceID uint) []orchestrator.SharedFolderMount {
 		mounts = append(mounts, orchestrator.SharedFolderMount{
 			VolumeID:  sf.ID,
 			MountPath: sf.MountPath,
+			HostPath:  sf.HostPath,
+			ReadOnly:  sf.ReadOnly,
 		})
 	}
 	return mounts

--- a/control-plane/internal/handlers/shared_folders.go
+++ b/control-plane/internal/handlers/shared_folders.go
@@ -6,11 +6,14 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gluk-w/claworc/control-plane/internal/analytics"
+	"github.com/gluk-w/claworc/control-plane/internal/config"
 	"github.com/gluk-w/claworc/control-plane/internal/database"
 	"github.com/gluk-w/claworc/control-plane/internal/middleware"
 	"github.com/gluk-w/claworc/control-plane/internal/orchestrator"
@@ -22,6 +25,136 @@ var reservedMountPrefixes = []string{
 	"/home/claworc",
 	"/home/linuxbrew",
 	"/dev/shm",
+}
+
+// ValidateHostMountPath verifies that a host bind-mount source path is permitted
+// by the operator allowlist. It is the single security gate for host-backed
+// shared folders. allowed is the list of permitted host path prefixes; an empty
+// list means the feature is disabled and every path is rejected.
+func ValidateHostMountPath(hostPath string, allowed []string) error {
+	// 1. Feature gate.
+	hasPrefix := false
+	for _, p := range allowed {
+		if strings.TrimSpace(p) != "" {
+			hasPrefix = true
+			break
+		}
+	}
+	if !hasPrefix {
+		return fmt.Errorf("host bind mounts are not enabled")
+	}
+
+	// 2. Absolute and already-clean (rejects "..", "//", trailing slashes).
+	if !strings.HasPrefix(hostPath, "/") {
+		return fmt.Errorf("host path must be absolute")
+	}
+	if filepath.Clean(hostPath) != hostPath {
+		return fmt.Errorf("host path must be a clean, absolute path (no '..', '.', or trailing slashes)")
+	}
+	if strings.Contains(hostPath, "..") {
+		return fmt.Errorf("host path must not contain '..'")
+	}
+
+	// 3. Allowlist containment (cleaned-vs-cleaned).
+	if !pathWithinAllowlist(hostPath, allowed) {
+		return fmt.Errorf("host path is not within an allowed prefix")
+	}
+
+	// 4. Symlink hardening: resolve and re-check. EvalSymlinks fails if the path
+	//    does not exist on the control-plane host (e.g. Kubernetes node paths);
+	//    in that case we fall back to the lexical check already performed above.
+	//    The allowlist prefixes are resolved too so that a symlinked ancestor of
+	//    the prefix itself (e.g. macOS /var -> /private/var) does not cause a
+	//    false rejection — only an escape beyond the resolved prefix is blocked.
+	if resolved, err := filepath.EvalSymlinks(hostPath); err == nil {
+		if !pathWithinAllowlist(resolved, resolveAllowlist(allowed)) {
+			return fmt.Errorf("host path resolves (via symlink) outside the allowed prefixes")
+		}
+	}
+
+	// 5. Defense-in-depth denylist of sensitive paths, even if the allowlist
+	//    would otherwise permit them.
+	for _, denied := range hostMountDenylist() {
+		if hostPath == denied || strings.HasPrefix(hostPath, denied+"/") {
+			return fmt.Errorf("host path overlaps a protected location")
+		}
+	}
+
+	return nil
+}
+
+// pathWithinAllowlist reports whether p equals or is nested under any non-empty
+// allowlisted prefix. Both sides are cleaned before comparison.
+func pathWithinAllowlist(p string, allowed []string) bool {
+	cp := filepath.Clean(p)
+	for _, prefix := range allowed {
+		prefix = strings.TrimSpace(prefix)
+		if prefix == "" {
+			continue
+		}
+		prefix = filepath.Clean(prefix)
+		if cp == prefix || strings.HasPrefix(cp, prefix+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// ensureHostPathDir creates the host bind-mount source directory (recursively)
+// if it does not yet exist. It only applies to the Docker backend, where the
+// control plane shares the host filesystem; on Kubernetes the path lives on the
+// node and is created/managed there. The caller must have already validated the
+// path against the allowlist. Returns ok=false with a user-facing message if the
+// directory cannot be created or is occupied by a non-directory.
+func ensureHostPathDir(hostPath string) (ok bool, msg string) {
+	orch := orchestrator.Get()
+	if orch == nil || orch.BackendName() != "docker" {
+		return true, ""
+	}
+	if info, err := os.Stat(hostPath); err == nil {
+		if !info.IsDir() {
+			return false, "host path exists but is not a directory"
+		}
+		return true, ""
+	} else if !os.IsNotExist(err) {
+		return false, "host path is not accessible"
+	}
+	if err := os.MkdirAll(hostPath, 0o755); err != nil {
+		return false, "could not create host directory"
+	}
+	return true, ""
+}
+
+// resolveAllowlist returns the allowlist prefixes with symlinks resolved where
+// possible, so the resolved-path containment check compares like with like.
+func resolveAllowlist(allowed []string) []string {
+	out := make([]string, 0, len(allowed))
+	for _, prefix := range allowed {
+		prefix = strings.TrimSpace(prefix)
+		if prefix == "" {
+			continue
+		}
+		if resolved, err := filepath.EvalSymlinks(prefix); err == nil {
+			out = append(out, resolved)
+		} else {
+			out = append(out, prefix)
+		}
+	}
+	return out
+}
+
+// hostMountDenylist returns paths that must never be bind-mounted regardless of
+// the allowlist: the Claworc data directory (Fernet key + encrypted secrets),
+// the Docker socket, and the SSH key directory.
+func hostMountDenylist() []string {
+	denied := []string{
+		"/var/run/docker.sock",
+		"/run/docker.sock",
+	}
+	if dp := strings.TrimSpace(config.Cfg.DataPath); dp != "" {
+		denied = append(denied, filepath.Clean(dp))
+	}
+	return denied
 }
 
 func isValidMountPath(p string) bool {
@@ -67,6 +200,8 @@ func ListSharedFolders(w http.ResponseWriter, r *http.Request) {
 		ID          uint   `json:"id"`
 		Name        string `json:"name"`
 		MountPath   string `json:"mount_path"`
+		HostPath    string `json:"host_path"`
+		ReadOnly    bool   `json:"read_only"`
 		OwnerID     uint   `json:"owner_id"`
 		InstanceIDs []uint `json:"instance_ids"`
 		TeamIDs     []uint `json:"team_ids"`
@@ -79,6 +214,8 @@ func ListSharedFolders(w http.ResponseWriter, r *http.Request) {
 			ID:          sf.ID,
 			Name:        sf.Name,
 			MountPath:   sf.MountPath,
+			HostPath:    sf.HostPath,
+			ReadOnly:    sf.ReadOnly,
 			OwnerID:     sf.OwnerID,
 			InstanceIDs: database.ParseSharedFolderInstanceIDs(sf.InstanceIDs),
 			TeamIDs:     database.ParseTeamIDs(sf.TeamIDs),
@@ -99,6 +236,8 @@ func CreateSharedFolder(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Name      string `json:"name"`
 		MountPath string `json:"mount_path"`
+		HostPath  string `json:"host_path"`
+		ReadOnly  *bool  `json:"read_only"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		writeError(w, http.StatusBadRequest, "Invalid request body")
@@ -122,10 +261,28 @@ func CreateSharedFolder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Host-backed folders default to read-only.
+	readOnly := true
+	if body.HostPath != "" {
+		if err := ValidateHostMountPath(body.HostPath, config.Cfg.AllowedHostMounts); err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("Invalid host path: %v", err))
+			return
+		}
+		if ok, msg := ensureHostPathDir(body.HostPath); !ok {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("Invalid host path: %s", msg))
+			return
+		}
+		if body.ReadOnly != nil {
+			readOnly = *body.ReadOnly
+		}
+	}
+
 	sf := &database.SharedFolder{
 		Name:      body.Name,
 		MountPath: body.MountPath,
 		OwnerID:   user.ID,
+		HostPath:  body.HostPath,
+		ReadOnly:  readOnly,
 	}
 	if err := database.CreateSharedFolder(sf); err != nil {
 		writeError(w, http.StatusInternalServerError, "Failed to create shared folder")
@@ -143,10 +300,32 @@ func CreateSharedFolder(w http.ResponseWriter, r *http.Request) {
 		"id":           sf.ID,
 		"name":         sf.Name,
 		"mount_path":   sf.MountPath,
+		"host_path":    sf.HostPath,
+		"read_only":    sf.ReadOnly,
 		"owner_id":     sf.OwnerID,
 		"instance_ids": []uint{},
 		"team_ids":     []uint{},
 		"created_at":   sf.CreatedAt.Format("2006-01-02T15:04:05Z"),
+	})
+}
+
+// HostMountConfig reports whether host-backed shared folders are enabled and,
+// if so, the allowlisted host path prefixes. The frontend uses this to decide
+// whether to show the "Mount to Host" option and to hint allowed locations.
+func HostMountConfig(w http.ResponseWriter, r *http.Request) {
+	if middleware.GetUser(r) == nil {
+		writeError(w, http.StatusUnauthorized, "Unauthorized")
+		return
+	}
+	prefixes := []string{}
+	for _, p := range config.Cfg.AllowedHostMounts {
+		if p = strings.TrimSpace(p); p != "" {
+			prefixes = append(prefixes, p)
+		}
+	}
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"enabled":          len(prefixes) > 0,
+		"allowed_prefixes": prefixes,
 	})
 }
 
@@ -178,6 +357,8 @@ func GetSharedFolder(w http.ResponseWriter, r *http.Request) {
 		"id":           sf.ID,
 		"name":         sf.Name,
 		"mount_path":   sf.MountPath,
+		"host_path":    sf.HostPath,
+		"read_only":    sf.ReadOnly,
 		"owner_id":     sf.OwnerID,
 		"instance_ids": database.ParseSharedFolderInstanceIDs(sf.InstanceIDs),
 		"team_ids":     database.ParseTeamIDs(sf.TeamIDs),
@@ -212,6 +393,8 @@ func UpdateSharedFolder(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Name        *string `json:"name"`
 		MountPath   *string `json:"mount_path"`
+		HostPath    *string `json:"host_path"`
+		ReadOnly    *bool   `json:"read_only"`
 		InstanceIDs *[]uint `json:"instance_ids"`
 		TeamIDs     *[]uint `json:"team_ids"`
 	}
@@ -220,9 +403,25 @@ func UpdateSharedFolder(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Host path is immutable after creation.
+	if body.HostPath != nil && *body.HostPath != sf.HostPath {
+		writeError(w, http.StatusBadRequest, "Host path cannot be changed after creation")
+		return
+	}
+
 	updates := map[string]interface{}{}
 	if body.Name != nil && *body.Name != "" {
 		updates["name"] = *body.Name
+	}
+	readOnlyChanged := false
+	if body.ReadOnly != nil && *body.ReadOnly != sf.ReadOnly {
+		// Read-only mode only affects host-backed folders.
+		if sf.HostPath == "" {
+			writeError(w, http.StatusBadRequest, "Read-only mode only applies to host-backed shared folders")
+			return
+		}
+		updates["read_only"] = *body.ReadOnly
+		readOnlyChanged = true
 	}
 	if body.MountPath != nil {
 		if !isValidMountPath(*body.MountPath) {
@@ -287,7 +486,7 @@ func UpdateSharedFolder(w http.ResponseWriter, r *http.Request) {
 	oldEffective := expandFolderEffectiveInstances(oldInstanceIDs, oldTeamIDs)
 	newEffective := expandFolderEffectiveInstances(newInstanceIDs, newTeamIDs)
 
-	for _, target := range computeFolderUpdateRestartTargets(oldEffective, newEffective, mountPathChanged, membershipChanged) {
+	for _, target := range computeFolderUpdateRestartTargets(oldEffective, newEffective, mountPathChanged || readOnlyChanged, membershipChanged) {
 		var inst database.Instance
 		if err := database.DB.First(&inst, target.InstanceID).Error; err != nil {
 			continue

--- a/control-plane/internal/handlers/shared_folders_readonly_test.go
+++ b/control-plane/internal/handlers/shared_folders_readonly_test.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"testing"
+
+	"github.com/gluk-w/claworc/control-plane/internal/database"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// TestSharedFolderReadWritePersists guards against the GORM default-tag gotcha:
+// a read-write (ReadOnly=false) host folder must persist as false, not be
+// silently flipped to read-only by a column default.
+func TestSharedFolderReadWritePersists(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open in-memory db: %v", err)
+	}
+	if err := db.AutoMigrate(&database.SharedFolder{}); err != nil {
+		t.Fatalf("auto-migrate: %v", err)
+	}
+	database.DB = db
+	t.Cleanup(func() { database.DB = nil })
+
+	rw := &database.SharedFolder{
+		Name:      "rw",
+		MountPath: "/shared/rw",
+		HostPath:  "/tmp/rw",
+		ReadOnly:  false,
+		OwnerID:   1,
+	}
+	if err := database.CreateSharedFolder(rw); err != nil {
+		t.Fatalf("create rw folder: %v", err)
+	}
+	ro := &database.SharedFolder{
+		Name:      "ro",
+		MountPath: "/shared/ro",
+		HostPath:  "/tmp/ro",
+		ReadOnly:  true,
+		OwnerID:   1,
+	}
+	if err := database.CreateSharedFolder(ro); err != nil {
+		t.Fatalf("create ro folder: %v", err)
+	}
+
+	gotRW, err := database.GetSharedFolder(rw.ID)
+	if err != nil {
+		t.Fatalf("get rw folder: %v", err)
+	}
+	if gotRW.ReadOnly {
+		t.Errorf("read-write folder persisted as read-only")
+	}
+
+	gotRO, err := database.GetSharedFolder(ro.ID)
+	if err != nil {
+		t.Fatalf("get ro folder: %v", err)
+	}
+	if !gotRO.ReadOnly {
+		t.Errorf("read-only folder persisted as read-write")
+	}
+}

--- a/control-plane/internal/handlers/shared_folders_validation_test.go
+++ b/control-plane/internal/handlers/shared_folders_validation_test.go
@@ -1,0 +1,65 @@
+package handlers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gluk-w/claworc/control-plane/internal/config"
+)
+
+func TestValidateHostMountPath(t *testing.T) {
+	// Real directory used to exercise the EvalSymlinks branch.
+	tmp := t.TempDir()
+	allowedDir := filepath.Join(tmp, "shared")
+	if err := os.MkdirAll(filepath.Join(allowedDir, "obsidian"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+
+	// A symlink inside the allowed dir pointing outside of it.
+	escape := filepath.Join(allowedDir, "escape")
+	if err := os.Symlink("/etc", escape); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	// Pretend the Claworc data dir lives under the allowlist to prove the
+	// defense-in-depth denylist still wins.
+	dataDir := filepath.Join(allowedDir, "claworc-data")
+	prevData := config.Cfg.DataPath
+	config.Cfg.DataPath = dataDir
+	t.Cleanup(func() { config.Cfg.DataPath = prevData })
+
+	allowed := []string{allowedDir}
+
+	tests := []struct {
+		name     string
+		hostPath string
+		allowed  []string
+		wantErr  bool
+	}{
+		{"feature disabled", filepath.Join(allowedDir, "obsidian"), nil, true},
+		{"feature disabled blank prefixes", filepath.Join(allowedDir, "obsidian"), []string{"", "  "}, true},
+		{"relative path", "relative/path", allowed, true},
+		{"parent traversal", allowedDir + "/../etc", allowed, true},
+		{"unclean trailing slash", filepath.Join(allowedDir, "obsidian") + "/", allowed, true},
+		{"outside allowlist", "/var/tmp/x", allowed, true},
+		{"docker socket", "/var/run/docker.sock", []string{"/var/run"}, true},
+		{"claworc data dir", dataDir, allowed, true},
+		{"claworc data subdir", filepath.Join(dataDir, "keys"), allowed, true},
+		{"symlink escape", escape, allowed, true},
+		{"exact prefix match", allowedDir, allowed, false},
+		{"valid subdir", filepath.Join(allowedDir, "obsidian"), allowed, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateHostMountPath(tt.hostPath, tt.allowed)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for %q, got nil", tt.hostPath)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("expected no error for %q, got %v", tt.hostPath, err)
+			}
+		})
+	}
+}

--- a/control-plane/internal/orchestrator/docker.go
+++ b/control-plane/internal/orchestrator/docker.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/docker/docker/api/types/container"
@@ -117,6 +118,38 @@ func (d *DockerOrchestrator) CloneVolume(ctx context.Context, srcVolName, dstVol
 	return d.copyVolume(ctx, srcVolName, dstVolName)
 }
 
+// ensureHostBindDir creates a host bind-mount source directory (recursively) if
+// it is within the CLAWORC_ALLOWED_HOST_MOUNTS allowlist. Re-checking the
+// allowlist here keeps directory creation safe even though the path was already
+// validated when the shared folder was created.
+func ensureHostBindDir(hostPath string) error {
+	clean := filepath.Clean(hostPath)
+	allowed := false
+	for _, prefix := range config.Cfg.AllowedHostMounts {
+		prefix = strings.TrimSpace(prefix)
+		if prefix == "" {
+			continue
+		}
+		prefix = filepath.Clean(prefix)
+		if clean == prefix || strings.HasPrefix(clean, prefix+"/") {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return fmt.Errorf("path is not within an allowed mount prefix")
+	}
+	if info, err := os.Stat(clean); err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("path exists but is not a directory")
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	return os.MkdirAll(clean, 0o755)
+}
+
 func parseCPUToNanoCPUs(cpuStr string) int64 {
 	if strings.HasSuffix(cpuStr, "m") {
 		val := cpuStr[:len(cpuStr)-1]
@@ -198,16 +231,7 @@ func (d *DockerOrchestrator) CreateInstance(ctx context.Context, params CreatePa
 	}
 
 	// Create shared folder volumes
-	for _, sfm := range params.SharedFolderMounts {
-		volName := fmt.Sprintf("claworc-shared-%d", sfm.VolumeID)
-		_, err := d.client.VolumeCreate(ctx, volume.CreateOptions{
-			Name:   volName,
-			Labels: map[string]string{"managed-by": labelManagedBy, "type": "shared-folder"},
-		})
-		if err != nil {
-			log.Printf("Shared volume %s may already exist: %v", volName, err)
-		}
-	}
+	d.ensureSharedVolumes(ctx, params.SharedFolderMounts)
 
 	progress("Creating container...")
 	return d.createContainer(ctx, params)
@@ -314,7 +338,19 @@ func (d *DockerOrchestrator) RestartInstance(ctx context.Context, name string, p
 	}
 
 	// Ensure shared folder volumes exist
-	for _, sfm := range params.SharedFolderMounts {
+	d.ensureSharedVolumes(ctx, params.SharedFolderMounts)
+
+	return d.createContainer(ctx, params)
+}
+
+// ensureSharedVolumes creates the managed Docker volumes backing each
+// non-host-backed shared folder. Existing volumes are tolerated.
+func (d *DockerOrchestrator) ensureSharedVolumes(ctx context.Context, mounts []SharedFolderMount) {
+	for _, sfm := range mounts {
+		// host-backed folders need no managed volume
+		if sfm.HostPath != "" {
+			continue
+		}
 		volName := fmt.Sprintf("claworc-shared-%d", sfm.VolumeID)
 		_, err := d.client.VolumeCreate(ctx, volume.CreateOptions{
 			Name:   volName,
@@ -324,8 +360,6 @@ func (d *DockerOrchestrator) RestartInstance(ctx context.Context, name string, p
 			log.Printf("Shared volume %s may already exist: %v", volName, err)
 		}
 	}
-
-	return d.createContainer(ctx, params)
 }
 
 func (d *DockerOrchestrator) UpdateImage(ctx context.Context, name string, params CreateParams) error {
@@ -371,6 +405,21 @@ func (d *DockerOrchestrator) createContainer(ctx context.Context, params CreateP
 		{Type: mount.TypeVolume, Source: d.volumeName(params.Name, "home"), Target: "/home/claworc"},
 	}
 	for _, sfm := range params.SharedFolderMounts {
+		if sfm.HostPath != "" {
+			// Create the host directory (recursively) so the bind mount can
+			// attach. Only paths within the operator allowlist are created, so
+			// a stale/shrunken allowlist can never auto-create arbitrary dirs.
+			if err := ensureHostBindDir(sfm.HostPath); err != nil {
+				return fmt.Errorf("prepare host mount %q: %w", sfm.HostPath, err)
+			}
+			mounts = append(mounts, mount.Mount{
+				Type:     mount.TypeBind,
+				Source:   sfm.HostPath,
+				Target:   sfm.MountPath,
+				ReadOnly: sfm.ReadOnly,
+			})
+			continue
+		}
 		mounts = append(mounts, mount.Mount{
 			Type:   mount.TypeVolume,
 			Source: fmt.Sprintf("claworc-shared-%d", sfm.VolumeID),
@@ -436,8 +485,12 @@ func (d *DockerOrchestrator) createContainer(ctx context.Context, params CreateP
 	}
 
 	// Fix ownership of shared folder mounts so the claworc user (1000:1000) can write to them.
-	// New Docker volumes are owned by root by default.
+	// New Docker volumes are owned by root by default. Host-backed bind mounts are
+	// skipped — we never modify ownership of the operator's host directories.
 	for _, sfm := range params.SharedFolderMounts {
+		if sfm.HostPath != "" {
+			continue
+		}
 		execCfg := container.ExecOptions{
 			Cmd: []string{"chown", "claworc:claworc", sfm.MountPath},
 		}

--- a/control-plane/internal/orchestrator/kubernetes.go
+++ b/control-plane/internal/orchestrator/kubernetes.go
@@ -113,8 +113,12 @@ func (k *KubernetesOrchestrator) CreateInstance(ctx context.Context, params Crea
 		}
 	}
 
-	// Create shared folder PVCs (ReadWriteMany for multi-pod access)
+	// Create shared folder PVCs (ReadWriteMany for multi-pod access).
 	for _, sfm := range params.SharedFolderMounts {
+		// Host-backed folders use a hostPath volume and need no PVC.
+		if sfm.HostPath != "" {
+			continue
+		}
 		pvcName := fmt.Sprintf("shared-folder-%d", sfm.VolumeID)
 		_, err := k.clientset.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
@@ -271,6 +275,10 @@ func (k *KubernetesOrchestrator) RestartInstance(ctx context.Context, name strin
 
 	// Ensure shared folder PVCs exist
 	for _, sfm := range params.SharedFolderMounts {
+		// host-backed folders need no PVC
+		if sfm.HostPath != "" {
+			continue
+		}
 		pvcName := fmt.Sprintf("shared-folder-%d", sfm.VolumeID)
 		_, err := k.clientset.CoreV1().PersistentVolumeClaims(ns).Get(ctx, pvcName, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
@@ -768,18 +776,25 @@ func buildInitContainers(sfMounts []SharedFolderMount, privileged bool) []corev1
 		var chownCmds []string
 		var volumeMounts []corev1.VolumeMount
 		for _, sfm := range sfMounts {
+			// Host-backed mounts use hostPath volumes; never chown the node's
+			// host directories.
+			if sfm.HostPath != "" {
+				continue
+			}
 			chownCmds = append(chownCmds, fmt.Sprintf("chown 1000:1000 %s", sfm.MountPath))
 			volumeMounts = append(volumeMounts, corev1.VolumeMount{
 				Name:      fmt.Sprintf("shared-%d", sfm.VolumeID),
 				MountPath: sfm.MountPath,
 			})
 		}
-		containers = append(containers, corev1.Container{
-			Name:         "fix-shared-permissions",
-			Image:        "busybox:latest",
-			Command:      []string{"sh", "-c", strings.Join(chownCmds, " && ")},
-			VolumeMounts: volumeMounts,
-		})
+		if len(chownCmds) > 0 {
+			containers = append(containers, corev1.Container{
+				Name:         "fix-shared-permissions",
+				Image:        "busybox:latest",
+				Command:      []string{"sh", "-c", strings.Join(chownCmds, " && ")},
+				VolumeMounts: volumeMounts,
+			})
+		}
 	}
 	return containers
 }
@@ -789,13 +804,30 @@ func appendSharedVolumeMounts(base []corev1.VolumeMount, sfMounts []SharedFolder
 		base = append(base, corev1.VolumeMount{
 			Name:      fmt.Sprintf("shared-%d", sfm.VolumeID),
 			MountPath: sfm.MountPath,
+			ReadOnly:  sfm.HostPath != "" && sfm.ReadOnly,
 		})
 	}
 	return base
 }
 
 func appendSharedVolumes(base []corev1.Volume, sfMounts []SharedFolderMount) []corev1.Volume {
+	hostPathDir := corev1.HostPathDirectory
 	for _, sfm := range sfMounts {
+		// Host-backed folders use a hostPath volume pinned to the node the pod
+		// is scheduled on; managed folders use the shared-folder PVC.
+		if sfm.HostPath != "" {
+			hp := sfm.HostPath
+			base = append(base, corev1.Volume{
+				Name: fmt.Sprintf("shared-%d", sfm.VolumeID),
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: hp,
+						Type: &hostPathDir,
+					},
+				},
+			})
+			continue
+		}
 		base = append(base, corev1.Volume{
 			Name: fmt.Sprintf("shared-%d", sfm.VolumeID),
 			VolumeSource: corev1.VolumeSource{

--- a/control-plane/internal/orchestrator/orchestrator.go
+++ b/control-plane/internal/orchestrator/orchestrator.go
@@ -76,6 +76,11 @@ type ContainerOrchestrator interface {
 type SharedFolderMount struct {
 	VolumeID  uint   // SharedFolder.ID, used to derive volume name
 	MountPath string // Container mount path
+	// HostPath, when non-empty, makes this a host bind mount backed by the given
+	// host directory instead of a managed volume/PVC.
+	HostPath string
+	// ReadOnly mounts the source read-only (used for host-backed mounts).
+	ReadOnly bool
 }
 
 type CreateParams struct {

--- a/control-plane/main.go
+++ b/control-plane/main.go
@@ -403,6 +403,7 @@ func main() {
 			// Shared Folders
 			r.Get("/shared-folders", handlers.ListSharedFolders)
 			r.Post("/shared-folders", handlers.CreateSharedFolder)
+			r.Get("/shared-folders/host-mount-config", handlers.HostMountConfig)
 			r.Get("/shared-folders/{id}", handlers.GetSharedFolder)
 			r.Put("/shared-folders/{id}", handlers.UpdateSharedFolder)
 			r.Delete("/shared-folders/{id}", handlers.DeleteSharedFolder)

--- a/docs/shared-folders.md
+++ b/docs/shared-folders.md
@@ -17,6 +17,8 @@ Any authenticated user can create shared folders and map them to instances they 
 | `MountPath`   | string   | Container mount path (same on all mapped instances) |
 | `OwnerID`     | uint     | User who created the folder                        |
 | `InstanceIDs` | string   | JSON array of instance IDs mapped to this folder   |
+| `HostPath`    | string   | If set, the folder is a host bind mount backed by this host directory (else a managed volume). Immutable after creation. |
+| `ReadOnly`    | bool     | Whether a host-backed mount is mounted read-only (defaults to `true`) |
 | `CreatedAt`   | datetime | Creation timestamp                                 |
 | `UpdatedAt`   | datetime | Last update timestamp                              |
 
@@ -40,6 +42,12 @@ All endpoints require authentication. In the protected route group (not admin-on
 { "name": "Shared Data", "mount_path": "/shared/data" }
 ```
 
+For a host-backed folder, add `host_path` (and optionally `read_only`, default `true`):
+
+```json
+{ "name": "Obsidian Vault", "mount_path": "/shared/obsidian", "host_path": "/Users/example/shared/obsidian", "read_only": false }
+```
+
 ### Update Request
 
 All fields are optional:
@@ -59,11 +67,20 @@ All fields are optional:
   "id": 1,
   "name": "Shared Data",
   "mount_path": "/shared/data",
+  "host_path": "",
+  "read_only": true,
   "owner_id": 1,
   "instance_ids": [1, 3],
   "created_at": "2026-04-03T10:00:00Z"
 }
 ```
+
+Host-backed folders also expose a config endpoint that reports whether the feature
+is enabled and which host path prefixes are permitted:
+
+| Method | Path                                  | Description                                |
+|--------|---------------------------------------|--------------------------------------------|
+| `GET`  | `/shared-folders/host-mount-config`   | `{ "enabled": bool, "allowed_prefixes": [] }` |
 
 ## Volume Lifecycle
 
@@ -76,21 +93,25 @@ Volumes are created by the orchestrator when an instance starts or restarts with
 
 ### Mounting
 
-When an instance is created, restarted, or has its image updated, the orchestrator reads shared folder mappings from the database and adds the corresponding volume mounts to the container/pod spec.
+When an instance is created, restarted, or has its image updated, the orchestrator reads shared folder mappings 
+from the database and adds the corresponding volume mounts to the container/pod spec.
 
 The mount path is the same for all instances mapped to a given shared folder.
 
 ### Automatic Restart on Mapping Changes
 
-When instance mappings or the mount path are changed (via `UpdateSharedFolder` or `DeleteSharedFolder`), all affected running instances are **automatically restarted** in the background. This includes:
+When instance mappings or the mount path are changed (via `UpdateSharedFolder` or `DeleteSharedFolder`), 
+all affected running instances are **automatically restarted** in the background. This includes:
 
 - Instances that were added to the folder (gain the mount)
 - Instances that were removed from the folder (lose the mount)
 - All mapped instances when the mount path changes
 
-The restart recreates the container (Docker: stop + remove + create; K8s: deployment update) with the current set of mounts. Stopped instances are skipped and will pick up changes on their next start.
+The restart recreates the container (Docker: stop + remove + create; K8s: deployment update) with the 
+current set of mounts. Stopped instances are skipped and will pick up changes on their next start.
 
-The helper `restartInstanceAsync` (in `instances.go`) handles SSH tunnel teardown, status updates, and the async restart. `buildCreateParams` constructs the full `CreateParams` from a database `Instance`.
+The helper `restartInstanceAsync` (in `instances.go`) handles SSH tunnel teardown, status updates, 
+and the async restart. `buildCreateParams` constructs the full `CreateParams` from a database `Instance`.
 
 ### Deletion
 
@@ -102,6 +123,56 @@ When a shared folder is deleted from the database:
 Orphaned volumes can be cleaned up manually:
 - Docker: `docker volume ls --filter label=type=shared-folder`
 - K8s: `kubectl get pvc -l type=shared-folder`
+
+## Host-Backed Shared Folders
+
+A shared folder can optionally be backed by a directory on the **host** (a Docker
+bind mount, or a Kubernetes `hostPath` volume) instead of a Claworc-managed volume.
+This is useful for integrating an instance with an existing local workflow — for
+example mounting an Obsidian/Syncthing vault into the agent.
+
+### Enabling the feature (operator opt-in)
+
+Host bind mounts are the most dangerous container primitive — an unrestricted bind
+mount could expose the Docker socket, the Claworc data directory, or arbitrary host
+files. The feature is therefore **disabled by default** and gated entirely by an
+operator-controlled allowlist:
+
+```
+CLAWORC_ALLOWED_HOST_MOUNTS=/Users/example/shared,/srv/data
+```
+
+- If the variable is unset/empty, the "Mount to Host" option is hidden in the UI and
+  the API rejects any request that includes a `host_path`.
+- If set, a host path is only accepted when it resolves to a location **within** one
+  of the listed prefixes.
+
+### Validation rules
+
+A `host_path` must:
+- Be absolute and already clean (no `..`, `.`, `//`, or trailing slashes)
+- Resolve (including through symlinks) to a path within an allowlisted prefix
+- Not overlap a protected location: the Docker socket or the Claworc data directory
+
+The container-side `mount_path` keeps the usual restrictions (see *Mount Path
+Restrictions* below).
+
+### Behavior
+
+- **Read-only by default.** New host-backed folders mount read-only; read-write must
+  be chosen explicitly. The access mode can be changed later (mapped instances
+  restart automatically); the host path itself is immutable after creation.
+- **No ownership changes.** Unlike managed volumes, Claworc never `chown`s a
+  host-backed mount — the operator's host directory is left untouched.
+
+### Kubernetes caveat
+
+On Kubernetes a host-backed folder becomes a `hostPath` volume, which binds to the
+filesystem of whichever **node** the pod is scheduled on. This is intended for
+single-node clusters; on multi-node clusters the directory must exist (with the same
+contents) on every eligible node. Symlink resolution is performed on the control
+plane only and cannot inspect node paths, so operators must trust the configured
+node directories.
 
 ## Access Control
 

--- a/website_docs/environment-variables.mdx
+++ b/website_docs/environment-variables.mdx
@@ -14,6 +14,7 @@ All Claworc configuration is done via environment variables with the `CLAWORC_` 
 | `CLAWORC_BACKUPS_PATH` | *(empty)* | Directory for backup archives. When empty, backups are written under `<CLAWORC_DATA_PATH>/backups`. Set this to place backups on a separate (for example, cheaper or slower) volume. The directory must exist and be writable. |
 | `CLAWORC_K8S_NAMESPACE` | `claworc` | Kubernetes namespace where agent instances are created. Must exist before starting. |
 | `CLAWORC_DOCKER_HOST` | *(empty)* | Docker socket or TCP address. Example: `unix:///var/run/docker.sock`. Leave empty to auto-detect orchestrator (Kubernetes takes priority). |
+| `CLAWORC_ALLOWED_HOST_MOUNTS` | *(empty)* | Comma-separated list of host path prefixes within which shared folders may be backed by a host directory (bind mount). Empty disables host-backed shared folders entirely. Only paths inside these prefixes are allowed; the Docker socket and `CLAWORC_DATA_PATH` are always blocked. See [Shared folders](/shared-folders). |
 
 ## Authentication
 

--- a/website_docs/shared-folders.mdx
+++ b/website_docs/shared-folders.mdx
@@ -52,6 +52,59 @@ Recommended mount paths: `/shared/<name>` or `/data/<name>`.
   Stopped instances pick up the change on their next start.
 </Warning>
 
+## Host-backed folders
+
+By default, a shared folder is backed by a Claworc-managed volume. You can instead back a folder
+with a real directory on the host machine — a Docker bind mount, or a Kubernetes `hostPath` volume.
+Use this to connect an instance to an existing local workflow, for example mounting an
+Obsidian or Syncthing vault into the instance so the agent reads and writes the same files you do.
+
+### Enabling host-backed folders
+
+Host-backed folders are disabled by default and must be enabled by an operator. They are gated by
+the `CLAWORC_ALLOWED_HOST_MOUNTS` environment variable, which lists the host path prefixes that may
+back a folder. See [Environment variables](/environment-variables).
+
+When `CLAWORC_ALLOWED_HOST_MOUNTS` is empty, the **Mount to Host** option is hidden in the dashboard
+and any host path is rejected. When it is set, you can back a folder with any host directory that
+resolves to a location within one of the allowed prefixes.
+
+### Creating a host-backed folder
+
+1. Open **Shared Folders** in the sidebar and click **New Folder**.
+2. Enter a name and a mount path as usual.
+3. Expand the **Mount to Host** region.
+4. Enter a **Host Path**. The dashboard shows the permitted prefixes and validates your entry inline.
+   The path must resolve to a location within one of the allowed prefixes.
+5. Pick an **Access Mode**. **Read-only** is the default; choose **Read-write** only if the instance
+   must write back to the host directory.
+6. Click **Create**.
+
+If the host directory does not exist, Claworc creates it automatically (including parent directories),
+as long as it is within an allowed prefix.
+
+The host path is fixed once the folder is created. You can change the access mode later, which restarts
+mapped running instances like any other shared-folder change.
+
+<Warning>
+  Host bind mounts give an instance direct access to files on the host. Keep these precautions in mind:
+
+  - Prefer **Read-only** unless the instance must write back to the host.
+  - Allowed prefixes should be scoped narrowly to a dedicated shared directory, not broad roots
+    like `/` or `/home`.
+  - The Docker socket and the Claworc data directory (`CLAWORC_DATA_PATH`) are always blocked, even
+    if an allowed prefix would otherwise permit them.
+  - Paths are normalized and symlink-resolved. Paths using `..` traversal or symlinks that escape an
+    allowed prefix are rejected.
+</Warning>
+
+<Note>
+  On Kubernetes, a host-backed folder becomes a `hostPath` volume bound to the node the instance's pod
+  runs on. This is intended for single-node clusters. On multi-node clusters, the directory must exist
+  with the same contents on every node the pod might run on, and symlink checks run on the control plane
+  only — they cannot inspect node filesystems.
+</Note>
+
 ## Deleting a shared folder
 
 Click the delete icon on the folder row and confirm. This removes the database record and


### PR DESCRIPTION
Lets a shared folder optionally be backed by a real host directory (Docker bind mount / Kubernetes `hostPath`) instead of a Claworc-managed volume.

- Gated by a new operator allowlist env var `CLAWORC_ALLOWED_HOST_MOUNTS` (empty default = feature fully disabled), so host access is opt-in and constrained to approved path prefixes.
- Adds host-mount path validation against the allowlist and a `GET /shared-folders/host-mount-config` endpoint so the UI can show the feature only when enabled.
- Docker and Kubernetes orchestrators gain host bind-mount / `hostPath` branches; Docker auto-creates the host directory tree.
- Folder modal gets a "Mount to Host" expandable region with a read-only toggle (host-backed folders default to read-only).
- Additive `HostPath` / `ReadOnly` model columns via AutoMigrate (no Goose migration). Tests cover path validation and read-write persistence.
- Technical and end-user docs updated.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)