### PR TITLE
fix: cancel in-flight browser spawn on agent delete/stop

### DIFF
--- a/control-plane/frontend/src/app/pages/AgentDetailPage.tsx
+++ b/control-plane/frontend/src/app/pages/AgentDetailPage.tsx
@@ -50,6 +50,7 @@ import EnvVarsEditor from "@common/components/EnvVarsEditor";
 import WebhookSection from "@common/components/WebhookSection";
 import LegacyBrowserBanner from "@common/components/LegacyBrowserBanner";
 import AppToast from "@common/components/AppToast";
+import { infoToast } from "@common/utils/toast";
 import toast from "react-hot-toast";
 import { useSSHStatus, useSSHEvents } from "@common/hooks/useSSHStatus";
 import { useInstanceLogs } from "@common/hooks/useInstanceLogs";
@@ -555,11 +556,16 @@ export default function AgentDetailPage() {
           onClone={(id) =>
             cloneMutation.mutate({ id, displayName: instance.display_name })
           }
-          onDelete={(id) =>
-            deleteMutation.mutate(id, {
-              onSuccess: () => navigate("/"),
-            })
-          }
+          onDelete={(id) => {
+            // Kick off deletion and leave the detail page right away — the agent
+            // is gone from the user's perspective. The slow browser-pod teardown
+            // finishes in the background; useDeleteInstance invalidates the list
+            // on success and surfaces an errorToast on failure (both fire even
+            // after we navigate away).
+            deleteMutation.mutate(id);
+            infoToast("Deleting agent…", instance.display_name);
+            navigate("/");
+          }}
         />
       </div>
 

--- a/control-plane/internal/handlers/browser.go
+++ b/control-plane/internal/handlers/browser.go
@@ -9,9 +9,28 @@ import (
 
 	"github.com/gluk-w/claworc/control-plane/internal/database"
 	"github.com/gluk-w/claworc/control-plane/internal/middleware"
+	"github.com/gluk-w/claworc/control-plane/internal/taskmanager"
 	"github.com/go-chi/chi/v5"
 	"gorm.io/gorm"
 )
+
+// cancelActiveBrowserSpawn cancels any in-flight browser.spawn task for the
+// instance. Delete and Stop call this so tearing down the browser pod can't
+// race a concurrent spawn that would recreate it, and the "Starting browser…"
+// toast stops spinning (the canceled task ends and its toast auto-dismisses).
+// Best-effort: no-op when TaskMgr is nil or nothing is in flight.
+func cancelActiveBrowserSpawn(instanceID uint) {
+	if TaskMgr == nil {
+		return
+	}
+	for _, t := range TaskMgr.List(taskmanager.Filter{
+		Type:       taskmanager.TaskBrowserSpawn,
+		InstanceID: instanceID,
+		OnlyActive: true,
+	}) {
+		_ = TaskMgr.Cancel(t.ID) // ignore ErrAlreadyTerminal / ErrNotFound
+	}
+}
 
 // browserStatusResponse is the JSON shape used by GET /browser/status. The
 // frontend desktop tab polls this to render a "starting browser" loading
@@ -118,6 +137,9 @@ func BrowserStop(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusServiceUnavailable, "browser bridge not configured")
 		return
 	}
+	// A stop while a spawn is still in flight must cancel the spawn, otherwise it
+	// finishes and re-marks the session running right after we stop it.
+	cancelActiveBrowserSpawn(uint(id))
 	if err := BrowserStopper.StopSession(r.Context(), uint(id)); err != nil {
 		writeError(w, http.StatusInternalServerError, err.Error())
 		return

--- a/control-plane/internal/handlers/instances.go
+++ b/control-plane/internal/handlers/instances.go
@@ -1596,6 +1596,9 @@ func DeleteInstance(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if orch := orchestrator.Get(); orch != nil {
+		// Cancel any in-flight browser spawn first so it can't recreate the pod
+		// we're about to delete (and so its toast stops spinning).
+		cancelActiveBrowserSpawn(inst.ID)
 		// Tear down the on-demand browser pod first so its container/volume
 		// don't outlive the agent. Best-effort: a failure here shouldn't
 		// block the agent cleanup or DB delete.
@@ -2065,6 +2068,9 @@ func cloneOnCancel(instanceID uint, cloneName string) taskmanager.OnCancel {
 				log.Printf("clone-cancel: stop tunnels for %d: %v", instanceID, err)
 			}
 		}
+		// Cancel any in-flight browser spawn for the destination so it can't
+		// recreate the pod we're about to delete.
+		cancelActiveBrowserSpawn(instanceID)
 		if BrowserAdmin != nil {
 			if err := BrowserAdmin.DeleteBrowserPod(ctx, instanceID); err != nil {
 				log.Printf("clone-cancel: delete browser pod for %s: %v", utils.SanitizeForLog(cloneName), err)

--- a/control-plane/internal/handlers/instances_lifecycle_test.go
+++ b/control-plane/internal/handlers/instances_lifecycle_test.go
@@ -1,13 +1,16 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gluk-w/claworc/control-plane/internal/orchestrator"
 	"github.com/gluk-w/claworc/control-plane/internal/sshproxy"
+	"github.com/gluk-w/claworc/control-plane/internal/taskmanager"
 )
 
 func TestStopInstance_StopsTunnels(t *testing.T) {
@@ -95,6 +98,61 @@ func TestDeleteInstance_StopsTunnels(t *testing.T) {
 	tunnels := tm.GetTunnelsForInstance(inst.ID)
 	if len(tunnels) != 0 {
 		t.Errorf("expected 0 tunnels after delete, got %d", len(tunnels))
+	}
+}
+
+// TestDeleteInstance_CancelsInflightBrowserSpawn verifies that deleting an
+// instance cancels its in-flight browser.spawn task, so the "Starting
+// browser…" toast stops spinning and the spawn can't recreate the pod we just
+// deleted.
+func TestDeleteInstance_CancelsInflightBrowserSpawn(t *testing.T) {
+	setupTestDB(t)
+	tm := withTaskMgr(t)
+
+	mock := &mockOrchestrator{}
+	orchestrator.Set(mock)
+	defer orchestrator.Set(nil)
+
+	inst := createTestInstance(t, "bot-del", "Delete Test")
+
+	// A long-running, cancellable spawn task that blocks until its ctx is
+	// canceled — mimicking doSpawn waiting on a cold-starting browser pod.
+	started := make(chan struct{})
+	taskID := tm.Start(taskmanager.StartOpts{
+		Type:       taskmanager.TaskBrowserSpawn,
+		InstanceID: inst.ID,
+		Title:      "Starting browser for Delete Test",
+		OnCancel:   func(context.Context) {},
+		Run: func(ctx context.Context, _ *taskmanager.Handle) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		},
+	})
+	<-started
+
+	req := buildRequest(t, "DELETE", "/api/v1/instances/1", nil, map[string]string{"id": fmt.Sprintf("%d", inst.ID)})
+	w := httptest.NewRecorder()
+	DeleteInstance(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected status 204, got %d (body: %s)", w.Code, w.Body.String())
+	}
+
+	// The spawn task must reach the canceled terminal state.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		task, ok := tm.Get(taskID)
+		if !ok {
+			t.Fatalf("task %s no longer known", taskID)
+		}
+		if task.State == taskmanager.StateCanceled {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected task to be canceled, got state %q", task.State)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 


### PR DESCRIPTION
Fixes browser-pod lifecycle bugs when an Agent (instance) is deleted or its browser is stopped while the on-demand browser pod is still spawning.

- Cancel any in-flight `browser.spawn` task for an instance before tearing down its browser pod (on delete, clone-cancel, and browser stop). This stops the "Starting browser…" toast from spinning ~120s and closes a race where the in-flight spawn could recreate the pod right after deletion, leaking an orphaned pod.
- Deleting an Agent from its details page now gives immediate feedback ("Deleting agent…") and navigates back to the list right away instead of blocking on the slower DELETE round-trip; list invalidation and error handling still run via the hook-level callbacks.
- Adds regression test covering spawn cancellation on instance delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)