### PR TITLE
feat(webhook): idle (activity-based) timeout for the synchronous webhook bridge

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,7 @@ Backend settings use `envconfig` with `CLAWORC_` env prefix (see `internal/confi
 - `CLAWORC_TERMINAL_RECORDING_DIR` - Directory for audit recordings (default: empty, disabled)
 - `CLAWORC_TERMINAL_SESSION_TIMEOUT` - Idle detached session timeout (default: `30m`)
 - `CLAWORC_ALLOWED_HOST_MOUNTS` - Comma-separated allowlist of host path prefixes within which shared folders may be backed by a host bind mount. Empty (default) disables host-backed shared folders entirely. See `docs/shared-folders.md`.
+- `CLAWORC_WEBHOOK_IDLE_TIMEOUT` - Idle gap the synchronous webhook bridge tolerates between events from OpenClaw before giving up (default: `120s`). The deadline re-arms on every event, so an actively-streaming agent is never cut off; only a genuine stall trips it.
 
 ## Terminology
 

--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"log"
+	"time"
 
 	"github.com/kelseyhightower/envconfig"
 )
@@ -32,6 +33,12 @@ type Settings struct {
 	// LLM gateway settings
 	LLMGatewayPort int    `envconfig:"LLM_GATEWAY_PORT" default:"40001"`
 	LLMResponseLog string `envconfig:"LLM_RESPONSE_LOG" default:""`
+
+	// WebhookIdleTimeout bounds how long the synchronous webhook bridge waits
+	// for the *next* event from OpenClaw before giving up. The deadline resets
+	// on every frame received, so an actively-streaming agent is never cut off;
+	// only a genuine stall trips it.
+	WebhookIdleTimeout time.Duration `envconfig:"WEBHOOK_IDLE_TIMEOUT" default:"120s"`
 }
 
 var Cfg Settings

--- a/control-plane/internal/handlers/webhook_bridge.go
+++ b/control-plane/internal/handlers/webhook_bridge.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/gluk-w/claworc/control-plane/internal/config"
 	"github.com/gluk-w/claworc/control-plane/internal/database"
 	"github.com/gluk-w/claworc/control-plane/internal/sshproxy"
 	"github.com/gluk-w/claworc/control-plane/internal/utils"
@@ -120,17 +121,27 @@ func RunWebhookBridge(ctx context.Context, instanceID uint, sessionName, message
 		return "", fmt.Errorf("send chat.send: %w", err)
 	}
 
+	// Idle (activity-based) deadline: each read is bounded by idle, and the
+	// timer re-arms on every frame received. An agent that keeps streaming
+	// events is never cut off; only a genuine stall (no events for idle) trips.
+	idle := config.Cfg.WebhookIdleTimeout
+	if idle <= 0 {
+		idle = 120 * time.Second
+	}
+
 	var assistantText string
 	for {
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		default:
-		}
-		_, data, err := gwConn.Read(ctx)
+		readCtx, cancel := context.WithTimeout(ctx, idle)
+		_, data, err := gwConn.Read(readCtx)
+		cancel()
 		if err != nil {
+			// Parent ctx cancelled => client disconnected or its own deadline.
 			if ctx.Err() != nil {
 				return "", ctx.Err()
+			}
+			// Per-read deadline fired => OpenClaw produced no events for idle.
+			if readCtx.Err() == context.DeadlineExceeded {
+				return "", fmt.Errorf("openclaw idle timeout: no events for %s", idle)
 			}
 			return "", fmt.Errorf("gateway read: %w", err)
 		}

--- a/control-plane/internal/handlers/webhook_bridge_test.go
+++ b/control-plane/internal/handlers/webhook_bridge_test.go
@@ -3,24 +3,26 @@ package handlers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/coder/websocket"
+	"github.com/gluk-w/claworc/control-plane/internal/config"
 	"github.com/gluk-w/claworc/control-plane/internal/database"
 )
 
-// fakeGateway runs a minimal OpenClaw gateway over WebSocket.
-// It completes the DialGateway handshake, captures the first chat.send frame,
-// sends a lifecycle/end event so RunWebhookBridge can return, then closes.
-// The captured chat.send params map is written to paramsCh.
-func fakeGateway(t *testing.T) (srv *httptest.Server, paramsCh <-chan map[string]any) {
+// fakeGatewayFunc runs a minimal OpenClaw gateway over WebSocket. It completes
+// the DialGateway handshake, reads the chat.send frame, and then hands control
+// to afterSend, which decides what events (if any) to stream back. The gateway's
+// request context is passed through so afterSend can observe client disconnect.
+func fakeGatewayFunc(t *testing.T, afterSend func(ctx context.Context, conn *websocket.Conn, params map[string]any)) *httptest.Server {
 	t.Helper()
-	ch := make(chan map[string]any, 1)
-	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
 		if err != nil {
 			t.Logf("ws accept: %v", err)
@@ -61,19 +63,95 @@ func fakeGateway(t *testing.T) (srv *httptest.Server, paramsCh <-chan map[string
 			return
 		}
 		params, _ := frame["params"].(map[string]any)
-		ch <- params
 
-		// Phase 5: send lifecycle/end so RunWebhookBridge returns
-		end, _ := json.Marshal(map[string]any{
-			"type": "event",
-			"payload": map[string]any{
-				"stream": "lifecycle",
-				"data":   map[string]any{"phase": "end"},
-			},
-		})
-		conn.Write(ctx, websocket.MessageText, end) //nolint:errcheck
+		afterSend(ctx, conn, params)
 	}))
+}
+
+// fakeGateway is the default gateway: it captures the chat.send params and
+// immediately sends a lifecycle/end event so RunWebhookBridge returns.
+func fakeGateway(t *testing.T) (srv *httptest.Server, paramsCh <-chan map[string]any) {
+	t.Helper()
+	ch := make(chan map[string]any, 1)
+	srv = fakeGatewayFunc(t, func(ctx context.Context, conn *websocket.Conn, params map[string]any) {
+		ch <- params
+		conn.Write(ctx, websocket.MessageText, lifecycleEndEvent()) //nolint:errcheck
+	})
 	return srv, ch
+}
+
+// assistantEvent builds an OpenClaw assistant event carrying a cumulative
+// snapshot in data.text.
+func assistantEvent(text string) []byte {
+	b, _ := json.Marshal(map[string]any{
+		"type": "event",
+		"payload": map[string]any{
+			"stream": "assistant",
+			"data":   map[string]any{"text": text},
+		},
+	})
+	return b
+}
+
+// lifecycleEndEvent builds the lifecycle/end event that signals completion.
+func lifecycleEndEvent() []byte {
+	b, _ := json.Marshal(map[string]any{
+		"type": "event",
+		"payload": map[string]any{
+			"stream": "lifecycle",
+			"data":   map[string]any{"phase": "end"},
+		},
+	})
+	return b
+}
+
+// gatewayPort extracts the listening port from a fake gateway test server.
+func gatewayPort(t *testing.T, srv *httptest.Server) int {
+	t.Helper()
+	addr := srv.Listener.Addr().String()
+	portStr := addr[strings.LastIndex(addr, ":")+1:]
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse port %q: %v", portStr, err)
+	}
+	return port
+}
+
+// pointTunnelTo overrides webhookGetTunnelPort to resolve to srv's port for the
+// duration of the test.
+func pointTunnelTo(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	port := gatewayPort(t, srv)
+	orig := webhookGetTunnelPort
+	webhookGetTunnelPort = func(_ uint, _ string) (int, error) { return port, nil }
+	t.Cleanup(func() { webhookGetTunnelPort = orig })
+}
+
+// setBridgeIdleTimeout sets the webhook idle timeout for the test and restores
+// the previous value on cleanup.
+func setBridgeIdleTimeout(t *testing.T, d time.Duration) {
+	t.Helper()
+	orig := config.Cfg.WebhookIdleTimeout
+	config.Cfg.WebhookIdleTimeout = d
+	t.Cleanup(func() { config.Cfg.WebhookIdleTimeout = orig })
+}
+
+// newBridgeInstance creates a running instance row for bridge tests.
+func newBridgeInstance(t *testing.T, uuid string) database.Instance {
+	t.Helper()
+	if err := database.DB.AutoMigrate(&database.WebhookApiKey{}, &database.WebhookLog{}); err != nil {
+		t.Fatalf("automigrate: %v", err)
+	}
+	inst := database.Instance{
+		UUID:        uuid,
+		Name:        "bot-" + uuid,
+		DisplayName: uuid,
+		Status:      "running",
+	}
+	if err := database.DB.Create(&inst).Error; err != nil {
+		t.Fatalf("create instance: %v", err)
+	}
+	return inst
 }
 
 func TestRunWebhookBridge_SessionKeyHasPrefix(t *testing.T) {
@@ -120,5 +198,108 @@ func TestRunWebhookBridge_SessionKeyHasPrefix(t *testing.T) {
 	idempotencyKey, _ := params["idempotencyKey"].(string)
 	if !strings.HasPrefix(idempotencyKey, "claworc-webhook-my-task-") {
 		t.Fatalf("idempotencyKey = %q, want prefix %q", idempotencyKey, "claworc-webhook-my-task-")
+	}
+}
+
+// TestRunWebhookBridge_IdleTimeout: a gateway that sends one event then goes
+// silent must trip the idle timeout rather than blocking forever.
+func TestRunWebhookBridge_IdleTimeout(t *testing.T) {
+	setupTestDB(t)
+	inst := newBridgeInstance(t, "bridge-idle-test")
+	setBridgeIdleTimeout(t, 200*time.Millisecond)
+
+	srv := fakeGatewayFunc(t, func(ctx context.Context, conn *websocket.Conn, _ map[string]any) {
+		// One event, then deliberate silence (never sends lifecycle/end).
+		conn.Write(ctx, websocket.MessageText, assistantEvent("working...")) //nolint:errcheck
+		<-ctx.Done()
+	})
+	defer srv.Close()
+	pointTunnelTo(t, srv)
+
+	_, err := RunWebhookBridge(context.Background(), inst.ID, "idle-task", "hello", nil)
+	if err == nil {
+		t.Fatalf("expected idle timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "openclaw idle timeout") {
+		t.Fatalf("error = %q, want idle timeout", err.Error())
+	}
+}
+
+// TestRunWebhookBridge_HeartbeatKeepsAlive: a gateway streaming events at an
+// interval shorter than the idle window — but for far longer than that window
+// in total — must NOT be cut off, proving the deadline re-arms per frame.
+func TestRunWebhookBridge_HeartbeatKeepsAlive(t *testing.T) {
+	setupTestDB(t)
+	inst := newBridgeInstance(t, "bridge-heartbeat-test")
+	setBridgeIdleTimeout(t, 200*time.Millisecond)
+
+	srv := fakeGatewayFunc(t, func(ctx context.Context, conn *websocket.Conn, _ map[string]any) {
+		// 12 events @ 50ms = ~600ms total, well past the 200ms idle window,
+		// but each gap (50ms) stays under it. Last snapshot is the reply.
+		for i := 0; i < 12; i++ {
+			text := "chunk-" + strconv.Itoa(i)
+			if err := conn.Write(ctx, websocket.MessageText, assistantEvent(text)); err != nil {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(50 * time.Millisecond):
+			}
+		}
+		conn.Write(ctx, websocket.MessageText, lifecycleEndEvent()) //nolint:errcheck
+	})
+	defer srv.Close()
+	pointTunnelTo(t, srv)
+
+	reply, err := RunWebhookBridge(context.Background(), inst.ID, "hb-task", "hello", nil)
+	if err != nil {
+		t.Fatalf("RunWebhookBridge: %v", err)
+	}
+	if reply != "chunk-11" {
+		t.Fatalf("reply = %q, want last snapshot %q", reply, "chunk-11")
+	}
+}
+
+// TestRunWebhookBridge_ClientDisconnect: cancelling the request context mid-
+// stream returns context.Canceled, not the idle-timeout error.
+func TestRunWebhookBridge_ClientDisconnect(t *testing.T) {
+	setupTestDB(t)
+	inst := newBridgeInstance(t, "bridge-disconnect-test")
+	setBridgeIdleTimeout(t, 5*time.Second) // generous, so idle never fires first
+
+	started := make(chan struct{}, 1)
+	srv := fakeGatewayFunc(t, func(ctx context.Context, conn *websocket.Conn, _ map[string]any) {
+		conn.Write(ctx, websocket.MessageText, assistantEvent("working...")) //nolint:errcheck
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-ctx.Done()
+	})
+	defer srv.Close()
+	pointTunnelTo(t, srv)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	type result struct {
+		err error
+	}
+	resCh := make(chan result, 1)
+	go func() {
+		_, err := RunWebhookBridge(ctx, inst.ID, "disc-task", "hello", nil)
+		resCh <- result{err}
+	}()
+
+	<-started
+	cancel()
+
+	select {
+	case res := <-resCh:
+		if !errors.Is(res.err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled", res.err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("RunWebhookBridge did not return after cancel")
 	}
 }

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -65,10 +65,15 @@ its `lifecycle/end` frame, then writes the assistant's final reply as
 `text/plain` (no JSON envelope). The body is the agent's response and
 nothing else — callers can pipe it directly into another tool.
 
-There is no internal timeout — the request is bounded by the caller's
-own HTTP client timeout (or by `r.Context()` cancellation when the
-client disconnects). Callers should size their timeout to the longest
-reply they expect from the agent.
+The only server-side limit is an **idle (activity-based) timeout**: the
+bridge re-arms a deadline on every event the agent streams back, so a
+reply that takes minutes is never cut off as long as the agent keeps
+making progress. If the agent goes silent for longer than
+`CLAWORC_WEBHOOK_IDLE_TIMEOUT` (default `120s`) the request fails with
+`502 Bad Gateway` (`openclaw idle timeout`). The request is otherwise
+bounded only by the caller's own HTTP client timeout (or by
+`r.Context()` cancellation when the client disconnects); callers should
+size their timeout to the longest reply they expect from the agent.
 
 ## Attachment delivery
 


### PR DESCRIPTION
## What & why

The synchronous webhook bridge had no server-side timeout, so a request was bounded only by the caller's HTTP client deadline. A long but healthy reply (120s+ of streaming) was indistinguishable from a hung agent. This adds an **idle (activity-based) timeout** so a request fails fast only when OpenClaw actually stalls, never while it is still streaming.

## Changes

- New `CLAWORC_WEBHOOK_IDLE_TIMEOUT` setting (`time.Duration`, default `120s`), parsed natively by envconfig.
- Read loop wraps each gateway read in a fresh deadline that **re-arms on every received frame** — an actively-streaming agent is never cut off.
- Read errors are now distinguished: client-disconnect (returns `ctx.Err()`), idle stall (`502` / `openclaw idle timeout`), and other read errors.
- Tests for idle-timeout, heartbeat-keeps-alive, and client-disconnect cases.
- Docs updated: `CLAUDE.md` setting reference and corrected the stale "no internal timeout" note in `docs/webhooks.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)