### PR TITLE
fix: pass all user env vars to Kubernetes deployment

### DIFF
--- a/control-plane/internal/orchestrator/kubernetes.go
+++ b/control-plane/internal/orchestrator/kubernetes.go
@@ -669,8 +669,8 @@ func buildDeployment(params CreateParams, ns string) *appsv1.Deployment {
 			corev1.EnvVar{Name: "DISPLAY_HEIGHT", Value: parts[1]},
 		)
 	}
-	if token, ok := params.EnvVars["OPENCLAW_GATEWAY_TOKEN"]; ok && token != "" {
-		envVars = append(envVars, corev1.EnvVar{Name: "OPENCLAW_GATEWAY_TOKEN", Value: token})
+	for k, v := range params.EnvVars {
+		envVars = append(envVars, corev1.EnvVar{Name: k, Value: v})
 	}
 	if params.Timezone != "" {
 		envVars = append(envVars, corev1.EnvVar{Name: "TZ", Value: params.Timezone})


### PR DESCRIPTION
buildDeployment only forwarded OPENCLAW_GATEWAY_TOKEN from CreateParams.EnvVars while the Docker backend iterated the full map. Instance env vars set via the UI (e.g. GITHUB_APP_*) were silently dropped on K8s, making them invisible inside the pod.