### PR TITLE
fix(ssh): prevent host key mismatch during Kubernetes rolling updates

### DIFF
--- a/control-plane/internal/orchestrator/kubernetes.go
+++ b/control-plane/internal/orchestrator/kubernetes.go
@@ -394,14 +394,19 @@ func (k *KubernetesOrchestrator) GetSSHAddress(ctx context.Context, instanceID u
 	if err != nil {
 		return "", 0, fmt.Errorf("list pods for instance %d: %w", instanceID, err)
 	}
-	if len(pods.Items) == 0 {
-		return "", 0, fmt.Errorf("no pods found for instance %d", instanceID)
+	// Skip terminating pods: during a rolling update both the old (Terminating)
+	// and new pod exist simultaneously. Connecting to the old pod stores its SSH
+	// host key, which then mismatches the new pod's key when the reconnect retries.
+	for _, pod := range pods.Items {
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		if pod.Status.PodIP == "" {
+			continue
+		}
+		return pod.Status.PodIP, 22, nil
 	}
-	pod := pods.Items[0]
-	if pod.Status.PodIP == "" {
-		return "", 0, fmt.Errorf("pod %s has no IP assigned (instance %d)", pod.Name, instanceID)
-	}
-	return pod.Status.PodIP, 22, nil
+	return "", 0, fmt.Errorf("no running pod found for instance %d (name: %s)", instanceID, inst.Name)
 }
 
 func (k *KubernetesOrchestrator) UpdateResources(ctx context.Context, name string, params UpdateResourcesParams) error {

--- a/control-plane/internal/sshproxy/reconnect.go
+++ b/control-plane/internal/sshproxy/reconnect.go
@@ -114,10 +114,8 @@ func (m *SSHManager) reconnectWithBackoff(ctx context.Context, instanceID uint, 
 		Details:    reason,
 	})
 
-	// Close stale connection and clear the stored host key before attempting
-	// reconnect. The container may have restarted with a new host key.
+	// Close stale connection before reconnecting.
 	m.Close(instanceID)
-	m.ClearHostKey(instanceID)
 
 	backoff := reconnectInitialBackoff
 	var lastErr error
@@ -130,6 +128,12 @@ func (m *SSHManager) reconnectWithBackoff(ctx context.Context, instanceID uint, 
 		}
 
 		log.Printf("SSH reconnect attempt %d/%d for instance %d", attempt, maxRetries, instanceID)
+
+		// Clear the stored host key before each attempt. During a Kubernetes rolling
+		// update, GetSSHAddress may briefly return the old (terminating) pod, whose
+		// SSH key gets stored. Clearing before every attempt ensures a stale key from
+		// a failed attempt never blocks the next one.
+		m.ClearHostKey(instanceID)
 
 		// Re-upload the global public key before each attempt
 		// (agent may have restarted, losing authorized_keys)


### PR DESCRIPTION
## Summary

- **`GetSSHAddress`** now skips pods with `DeletionTimestamp != nil`. During a rolling update both the old (Terminating) and new pod match the `app=` label selector simultaneously. The platform could dial the dying pod, store its SSH host key, and then fail with `host key mismatch` when it eventually reached the new pod.
- **`reconnectWithBackoff`** clears the stored host key before every attempt instead of only once at the start. A key recorded during a failed attempt can no longer block subsequent ones.

## Root cause

SSH host keys are baked into the Docker image. On a rolling update `GetSSHAddress` was doing `pods.Items[0]` with no status check, so it could return the terminating pod's IP. `reconnectWithBackoff` would connect to it, store the old key, then the pod would die. When the reconciler finally reached the new pod with the new key it got `host key mismatch`, which then escalated the rate-limit cooldown to ~5 min. Recovery required a manual platform restart.

## Test plan

- [ ] Deploy a new bot image → tunnel should come up automatically without restarting the platform
- [ ] Check platform logs: no `host key mismatch` for the instance after rollout
- [x] `go build ./internal/sshproxy/... ./internal/orchestrator/...` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)