### PR TITLE
Inbound SSH gateway: ssh user+instance@claworc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ Backend settings use `envconfig` with `CLAWORC_` env prefix (see `internal/confi
 - `CLAWORC_TERMINAL_SESSION_TIMEOUT` - Idle detached session timeout (default: `30m`)
 - `CLAWORC_ALLOWED_HOST_MOUNTS` - Comma-separated allowlist of host path prefixes within which shared folders may be backed by a host bind mount. Empty (default) disables host-backed shared folders entirely. See `docs/shared-folders.md`.
 - `CLAWORC_WEBHOOK_IDLE_TIMEOUT` - Idle gap the synchronous webhook bridge tolerates between events from OpenClaw before giving up (default: `120s`). The deadline re-arms on every event, so an actively-streaming agent is never cut off; only a genuine stall trips it.
+- `CLAWORC_SSH_GATEWAY_ENABLED` / `CLAWORC_SSH_GATEWAY_PORT` / `CLAWORC_SSH_GATEWAY_PUBLIC_HOST` - Inbound SSH gateway (`ssh <user>+<instance>@host`, default port `2222`). See `docs/ssh-gateway.md`.
 
 ## Terminology
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ for your clients from one place.
 - **Chat with agents** — send instructions and have a conversation with the AI agent in each instance
 - **Watch the browser** — see what the agent is doing in Chrome in real time, or take control yourself
 - **Use the terminal** — open interactive SSH terminal sessions with session persistence and scrollback
+- **SSH from your machine** — connect to any agent with a plain SSH client (`ssh you+agent-name@host`) using a personal key generated on your profile page
 - **Manage files** — browse, upload, download, and edit files in each instance's workspace over SSH
 - **View logs** — stream live logs to monitor what's happening inside an instance
 

--- a/control-plane/cmd/migrationcheck/main.go
+++ b/control-plane/cmd/migrationcheck/main.go
@@ -74,6 +74,7 @@ func allMigratedModels() []interface{} {
 		&database.User{},
 		&database.UserInstance{},
 		&database.WebAuthnCredential{},
+		&database.UserSSHKey{},
 		&database.LLMProvider{},
 		&database.LLMGatewayKey{},
 		&database.Skill{},

--- a/control-plane/frontend/src/app/pages/AccountPage.tsx
+++ b/control-plane/frontend/src/app/pages/AccountPage.tsx
@@ -1,6 +1,13 @@
 import { useState, type FormEvent } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Trash2, ShieldCheck, Shield, Fingerprint, KeyRound } from "lucide-react";
+import {
+  Trash2,
+  ShieldCheck,
+  Shield,
+  Fingerprint,
+  KeyRound,
+  TerminalSquare,
+} from "lucide-react";
 import { startRegistration } from "@simplewebauthn/browser";
 import { successToast, errorToast, infoToast } from "@common/utils/toast";
 import { useAuth } from "@common/contexts/AuthContext";
@@ -11,6 +18,12 @@ import {
   webAuthnRegisterFinish,
   changePassword,
 } from "@common/api/auth";
+import {
+  listSSHKeys,
+  generateSSHKey,
+  deleteSSHKey,
+  getSSHGatewayInfo,
+} from "@common/api/sshKeys";
 import Page from "@common/components/Page";
 
 export default function AccountPage() {
@@ -68,6 +81,8 @@ export default function AccountPage() {
           </button>
         </div>
       </div>
+
+      <SSHAccessCard username={user?.username || ""} />
 
       <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
         <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
@@ -153,6 +168,203 @@ export default function AccountPage() {
         <ChangePasswordDialog onClose={() => setShowChangePassword(false)} />
       )}
     </Page>
+  );
+}
+
+function SSHAccessCard({ username }: { username: string }) {
+  const queryClient = useQueryClient();
+  const [showKeyDialog, setShowKeyDialog] = useState(false);
+
+  const { data: info } = useQuery({
+    queryKey: ["ssh-gateway-info"],
+    queryFn: getSSHGatewayInfo,
+  });
+  const { data: keys = [], isLoading } = useQuery({
+    queryKey: ["ssh-keys"],
+    queryFn: listSSHKeys,
+  });
+
+  const keyFileName = `claworc_${username || "user"}.pem`;
+
+  const generateMut = useMutation({
+    mutationFn: () => generateSSHKey(),
+    onSuccess: (res) => {
+      queryClient.invalidateQueries({ queryKey: ["ssh-keys"] });
+      // One-time download of the private key: it is never stored server-side.
+      const blob = new Blob([res.private_key], {
+        type: "application/x-pem-file",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = keyFileName;
+      a.click();
+      URL.revokeObjectURL(url);
+      setShowKeyDialog(true);
+    },
+    onError: (error) => errorToast("Failed to generate SSH key", error),
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: (id: number) => deleteSSHKey(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["ssh-keys"] });
+      successToast("SSH key revoked");
+    },
+    onError: (error) => errorToast("Failed to revoke SSH key", error),
+  });
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 overflow-hidden mb-6">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-gray-200">
+        <h2 className="text-sm font-medium text-gray-500">SSH Access</h2>
+        <button
+          onClick={() => generateMut.mutate()}
+          disabled={generateMut.isPending || info?.enabled === false}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 disabled:opacity-50"
+        >
+          <TerminalSquare size={16} />
+          {generateMut.isPending ? "Generating..." : "Generate SSH Key"}
+        </button>
+      </div>
+
+      {info?.enabled === false ? (
+        <div className="px-4 py-6 text-sm text-gray-500">
+          SSH access is disabled by the administrator.
+        </div>
+      ) : isLoading ? (
+        <div className="px-4 py-6 text-sm text-gray-500">Loading SSH keys...</div>
+      ) : keys.length === 0 ? (
+        <div className="px-4 py-6 text-sm text-gray-500">
+          No SSH keys yet. Generate one to connect to your agents from a
+          terminal. The private key is downloaded once and never stored on the
+          server.
+        </div>
+      ) : (
+        <table className="w-full text-sm">
+          <thead className="bg-gray-50 border-b border-gray-200">
+            <tr>
+              <th className="text-left px-4 py-3 font-medium text-gray-600">
+                Fingerprint
+              </th>
+              <th className="text-left px-4 py-3 font-medium text-gray-600">
+                Created
+              </th>
+              <th className="text-left px-4 py-3 font-medium text-gray-600">
+                Last Used
+              </th>
+              <th className="text-right px-4 py-3 font-medium text-gray-600">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {keys.map((key) => (
+              <tr key={key.id} className="border-b border-gray-100 last:border-0">
+                <td className="px-4 py-3 text-gray-500 font-mono text-xs">
+                  {key.fingerprint}
+                </td>
+                <td className="px-4 py-3 text-gray-500">
+                  {key.created_at
+                    ? new Date(key.created_at).toLocaleDateString()
+                    : "—"}
+                </td>
+                <td className="px-4 py-3 text-gray-500">
+                  {key.last_used_at
+                    ? new Date(key.last_used_at).toLocaleString()
+                    : "Never"}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <button
+                    onClick={() => {
+                      if (confirm("Revoke this SSH key?")) {
+                        deleteMut.mutate(key.id);
+                      }
+                    }}
+                    className="p-1.5 text-gray-400 hover:text-red-600 rounded"
+                    title="Revoke SSH key"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {showKeyDialog && (
+        <SSHKeyGeneratedDialog
+          username={username}
+          keyFileName={keyFileName}
+          gatewayPort={info?.port}
+          gatewayHost={info?.host || window.location.hostname}
+          onClose={() => setShowKeyDialog(false)}
+        />
+      )}
+    </div>
+  );
+}
+
+function SSHKeyGeneratedDialog({
+  username,
+  keyFileName,
+  gatewayPort,
+  gatewayHost,
+  onClose,
+}: {
+  username: string;
+  keyFileName: string;
+  gatewayPort?: number;
+  gatewayHost: string;
+  onClose: () => void;
+}) {
+  const portFlag = gatewayPort && gatewayPort !== 22 ? ` -p ${gatewayPort}` : "";
+  const sshCommand = `ssh -i ~/.ssh/${keyFileName}${portFlag} ${username || "<you>"}+<agent-name>@${gatewayHost}`;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50"
+      onKeyDown={(e) => { if (e.key === "Escape") onClose(); }}
+    >
+      <div className="bg-white rounded-lg shadow-lg w-full max-w-lg p-6">
+        <h2 className="text-lg font-semibold mb-2">SSH Key Generated</h2>
+        <p className="text-sm text-gray-600 mb-4">
+          Your private key <span className="font-mono">{keyFileName}</span> is
+          being downloaded. It is not stored on the server, so keep the file
+          safe — if you lose it, generate a new key.
+        </p>
+
+        <div className="space-y-3 text-sm text-gray-700">
+          <div>
+            <div className="font-medium text-gray-900 mb-1">
+              1. Move the key into place and restrict its permissions:
+            </div>
+            <code className="block px-3 py-2 text-xs font-mono bg-gray-900 text-gray-100 rounded-md overflow-x-auto whitespace-nowrap">
+              mv ~/Downloads/{keyFileName} ~/.ssh/ && chmod 600 ~/.ssh/{keyFileName}
+            </code>
+          </div>
+          <div>
+            <div className="font-medium text-gray-900 mb-1">
+              2. Connect to an agent by name:
+            </div>
+            <code className="block px-3 py-2 text-xs font-mono bg-gray-900 text-gray-100 rounded-md overflow-x-auto whitespace-nowrap">
+              {sshCommand}
+            </code>
+          </div>
+        </div>
+
+        <div className="flex justify-end pt-5">
+          <button
+            onClick={onClose}
+            autoFocus
+            className="px-3 py-1.5 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700"
+          >
+            Done
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/control-plane/frontend/src/common/api/sshKeys.ts
+++ b/control-plane/frontend/src/common/api/sshKeys.ts
@@ -1,0 +1,44 @@
+import client from "./client";
+
+export interface UserSSHKey {
+  id: number;
+  name: string;
+  fingerprint: string;
+  created_at: string;
+  last_used_at?: string;
+}
+
+export interface GenerateSSHKeyResult {
+  key: UserSSHKey;
+  private_key: string;
+}
+
+export interface SSHGatewayInfo {
+  enabled: boolean;
+  port: number;
+  host: string;
+}
+
+export async function listSSHKeys(): Promise<UserSSHKey[]> {
+  const res = await client.get("/auth/ssh-keys");
+  return res.data;
+}
+
+export async function generateSSHKey(name?: string): Promise<GenerateSSHKeyResult> {
+  const res = await client.post("/auth/ssh-keys/generate", { name });
+  return res.data;
+}
+
+export async function uploadSSHKey(name: string, publicKey: string): Promise<{ key: UserSSHKey }> {
+  const res = await client.post("/auth/ssh-keys", { name, public_key: publicKey });
+  return res.data;
+}
+
+export async function deleteSSHKey(id: number): Promise<void> {
+  await client.delete(`/auth/ssh-keys/${id}`);
+}
+
+export async function getSSHGatewayInfo(): Promise<SSHGatewayInfo> {
+  const res = await client.get("/ssh-gateway/info");
+  return res.data;
+}

--- a/control-plane/internal/config/config.go
+++ b/control-plane/internal/config/config.go
@@ -34,6 +34,14 @@ type Settings struct {
 	LLMGatewayPort int    `envconfig:"LLM_GATEWAY_PORT" default:"40001"`
 	LLMResponseLog string `envconfig:"LLM_RESPONSE_LOG" default:""`
 
+	// SSH gateway settings. The gateway lets users `ssh <user>+<instance>@host`
+	// and be bridged onto the control plane's existing SSH connection to that
+	// instance. SSHGatewayPublicHost is display-only: the hostname shown in the
+	// frontend usage snippet (empty = frontend uses window.location.hostname).
+	SSHGatewayEnabled    bool   `envconfig:"SSH_GATEWAY_ENABLED" default:"true"`
+	SSHGatewayPort       int    `envconfig:"SSH_GATEWAY_PORT" default:"2222"`
+	SSHGatewayPublicHost string `envconfig:"SSH_GATEWAY_PUBLIC_HOST" default:""`
+
 	// WebhookIdleTimeout bounds how long the synchronous webhook bridge waits
 	// for the *next* event from OpenClaw before giving up. The deadline resets
 	// on every frame received, so an actively-streaming agent is never cut off;

--- a/control-plane/internal/database/database.go
+++ b/control-plane/internal/database/database.go
@@ -272,6 +272,46 @@ func GetFirstAdmin() (*User, error) {
 	return &u, nil
 }
 
+// User SSH key helpers
+
+func CreateUserSSHKey(k *UserSSHKey) error {
+	return DB.Create(k).Error
+}
+
+func ListUserSSHKeys(userID uint) ([]UserSSHKey, error) {
+	var keys []UserSSHKey
+	if err := DB.Where("user_id = ?", userID).Order("id").Find(&keys).Error; err != nil {
+		return nil, err
+	}
+	return keys, nil
+}
+
+func GetUserSSHKeyByFingerprint(fingerprint string) (*UserSSHKey, error) {
+	var k UserSSHKey
+	if err := DB.Where("fingerprint = ?", fingerprint).First(&k).Error; err != nil {
+		return nil, err
+	}
+	return &k, nil
+}
+
+// DeleteUserSSHKey removes a key only if it belongs to the given user.
+func DeleteUserSSHKey(userID, keyID uint) error {
+	res := DB.Where("id = ? AND user_id = ?", keyID, userID).Delete(&UserSSHKey{})
+	if res.Error != nil {
+		return res.Error
+	}
+	if res.RowsAffected == 0 {
+		return gorm.ErrRecordNotFound
+	}
+	return nil
+}
+
+// TouchUserSSHKeyUsed records the current time as the key's last use. Best effort.
+func TouchUserSSHKeyUsed(keyID uint) {
+	now := time.Now()
+	DB.Model(&UserSSHKey{}).Where("id = ?", keyID).Update("last_used_at", &now)
+}
+
 // Instance assignment helpers
 
 func GetUserInstances(userID uint) ([]uint, error) {

--- a/control-plane/internal/database/migrations/migration_00001_baseline.go
+++ b/control-plane/internal/database/migrations/migration_00001_baseline.go
@@ -45,6 +45,7 @@ func AutoMigrateAll(gdb interface {
 		&models.User{},
 		&models.UserInstance{},
 		&models.WebAuthnCredential{},
+		&models.UserSSHKey{},
 		&models.LLMProvider{},
 		&models.LLMGatewayKey{},
 		&models.Skill{},

--- a/control-plane/internal/database/migrations/migration_00009_noop_user_ssh_keys.go
+++ b/control-plane/internal/database/migrations/migration_00009_noop_user_ssh_keys.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+// 00009_noop_user_ssh_keys: registry placeholder for the new UserSSHKey
+// model (user_ssh_keys table) added for the inbound SSH gateway feature.
+//
+// Per docs/migrations.md, a brand new table is handled by AutoMigrateAll
+// on boot and does not require a Goose migration. However, the CI
+// "Migration Drift Check" guard in .github/workflows/control-plane.yml
+// errors out whenever models/models.go changes without a new migration file,
+// so we register a no-op here to satisfy that guard and keep the goose
+// registry contiguous.
+func init() {
+	register(&goose.Migration{
+		Version: 9,
+		Source:  "00009_noop_user_ssh_keys.go",
+		UpFnContext: func(ctx context.Context, tx *sql.Tx) error {
+			return nil
+		},
+		DownFnContext: func(ctx context.Context, tx *sql.Tx) error {
+			return nil
+		},
+	})
+}

--- a/control-plane/internal/database/models.go
+++ b/control-plane/internal/database/models.go
@@ -32,6 +32,7 @@ type (
 	KanbanArtifact     = models.KanbanArtifact
 	InstanceSoul       = models.InstanceSoul
 	WebAuthnCredential = models.WebAuthnCredential
+	UserSSHKey         = models.UserSSHKey
 	WebhookApiKey      = models.WebhookApiKey
 	WebhookLog         = models.WebhookLog
 )

--- a/control-plane/internal/database/models/models.go
+++ b/control-plane/internal/database/models/models.go
@@ -433,3 +433,16 @@ type WebAuthnCredential struct {
 	AAGUID          []byte    `json:"-"`
 	CreatedAt       time.Time `gorm:"autoCreateTime" json:"created_at"`
 }
+
+// UserSSHKey is a public key a user authenticates with against the inbound
+// SSH gateway. The private key is never stored — it is generated on demand
+// and handed to the user exactly once (or the user uploads their own pubkey).
+type UserSSHKey struct {
+	ID          uint       `gorm:"primaryKey;autoIncrement" json:"id"`
+	UserID      uint       `gorm:"not null;index" json:"user_id"`
+	Name        string     `gorm:"not null;default:''" json:"name"`
+	PublicKey   string     `gorm:"type:text;not null" json:"-"` // authorized_keys format
+	Fingerprint string     `gorm:"uniqueIndex;not null;size:64" json:"fingerprint"` // ssh.FingerprintSHA256
+	LastUsedAt  *time.Time `json:"last_used_at,omitempty"`
+	CreatedAt   time.Time  `gorm:"autoCreateTime" json:"created_at"`
+}

--- a/control-plane/internal/database/teams.go
+++ b/control-plane/internal/database/teams.go
@@ -15,6 +15,40 @@ func GetInstance(id uint) (*Instance, error) {
 	return &inst, nil
 }
 
+// GetInstanceByName fetches an Instance by its unique K8s-safe name.
+func GetInstanceByName(name string) (*Instance, error) {
+	var inst Instance
+	if err := DB.Where("name = ?", name).First(&inst).Error; err != nil {
+		return nil, err
+	}
+	return &inst, nil
+}
+
+// CanUserAccessInstance reports whether the user may access the instance:
+// admins always; managers of the instance's team; regular team members with
+// an explicit UserInstance grant. This is the single source of truth —
+// middleware.CanAccessInstance and the SSH gateway both delegate here.
+func CanUserAccessInstance(user *User, instanceID uint) bool {
+	if user == nil {
+		return false
+	}
+	if user.Role == "admin" {
+		return true
+	}
+	inst, err := GetInstance(instanceID)
+	if err == nil {
+		role := GetTeamRole(user.ID, inst.TeamID)
+		if role == TeamRoleManager {
+			return true
+		}
+		if role == TeamRoleUser && IsUserAssignedToInstance(user.ID, instanceID) {
+			return true
+		}
+		return false
+	}
+	return IsUserAssignedToInstance(user.ID, instanceID)
+}
+
 // Team role constants. Stored as the Role column on TeamMember.
 const (
 	TeamRoleUser    = "user"

--- a/control-plane/internal/handlers/user_ssh_keys.go
+++ b/control-plane/internal/handlers/user_ssh_keys.go
@@ -170,7 +170,7 @@ func DeleteUserSSHKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	keyID, err := strconv.ParseUint(chi.URLParam(r, "keyId"), 10, 64)
+	keyID, err := strconv.ParseUint(chi.URLParam(r, "keyId"), 10, 32)
 	if err != nil {
 		writeError(w, http.StatusBadRequest, "Invalid key ID")
 		return

--- a/control-plane/internal/handlers/user_ssh_keys.go
+++ b/control-plane/internal/handlers/user_ssh_keys.go
@@ -1,0 +1,208 @@
+// user_ssh_keys.go manages per-user SSH public keys for the inbound SSH
+// gateway. Keys can be generated server-side (the private key is returned
+// exactly once and never stored) or uploaded by the user.
+
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"golang.org/x/crypto/ssh"
+	"gorm.io/gorm"
+
+	"github.com/gluk-w/claworc/control-plane/internal/config"
+	"github.com/gluk-w/claworc/control-plane/internal/database"
+	"github.com/gluk-w/claworc/control-plane/internal/middleware"
+	"github.com/gluk-w/claworc/control-plane/internal/sshaudit"
+	"github.com/gluk-w/claworc/control-plane/internal/sshproxy"
+)
+
+type userSSHKeyResponse struct {
+	ID          uint   `json:"id"`
+	Name        string `json:"name"`
+	Fingerprint string `json:"fingerprint"`
+	CreatedAt   string `json:"created_at"`
+	LastUsedAt  string `json:"last_used_at,omitempty"`
+}
+
+func toUserSSHKeyResponse(k database.UserSSHKey) userSSHKeyResponse {
+	resp := userSSHKeyResponse{
+		ID:          k.ID,
+		Name:        k.Name,
+		Fingerprint: k.Fingerprint,
+		CreatedAt:   formatTimestamp(k.CreatedAt),
+	}
+	if k.LastUsedAt != nil {
+		resp.LastUsedAt = formatTimestamp(*k.LastUsedAt)
+	}
+	return resp
+}
+
+// GenerateUserSSHKey creates an ED25519 key pair for the current user,
+// stores the public key, and returns the private key once.
+func GenerateUserSSHKey(w http.ResponseWriter, r *http.Request) {
+	user := middleware.GetUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+
+	var body struct {
+		Name string `json:"name"`
+	}
+	json.NewDecoder(r.Body).Decode(&body) // body is optional
+
+	pubKey, privKeyPEM, err := sshproxy.GenerateOpenSSHKeyPair()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "Failed to generate key pair")
+		return
+	}
+
+	key, err := storeUserSSHKey(user.ID, body.Name, string(pubKey))
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "Failed to store key")
+		return
+	}
+
+	auditKeyEvent(user.Username, "generated", key)
+	writeJSON(w, http.StatusCreated, map[string]interface{}{
+		"key":         toUserSSHKeyResponse(*key),
+		"private_key": string(privKeyPEM),
+	})
+}
+
+// UploadUserSSHKey registers a user-provided public key.
+func UploadUserSSHKey(w http.ResponseWriter, r *http.Request) {
+	user := middleware.GetUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+
+	var body struct {
+		Name      string `json:"name"`
+		PublicKey string `json:"public_key"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil || strings.TrimSpace(body.PublicKey) == "" {
+		writeError(w, http.StatusBadRequest, "public_key is required")
+		return
+	}
+
+	key, err := storeUserSSHKey(user.ID, body.Name, body.PublicKey)
+	if err != nil {
+		if errors.Is(err, errInvalidPublicKey) {
+			writeError(w, http.StatusBadRequest, "Invalid public key (expected OpenSSH authorized_keys format)")
+			return
+		}
+		if isDuplicateKeyError(err) {
+			writeError(w, http.StatusConflict, "This key is already registered")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "Failed to store key")
+		return
+	}
+
+	auditKeyEvent(user.Username, "uploaded", key)
+	writeJSON(w, http.StatusCreated, map[string]interface{}{"key": toUserSSHKeyResponse(*key)})
+}
+
+var errInvalidPublicKey = errors.New("invalid public key")
+
+func storeUserSSHKey(userID uint, name, publicKey string) (*database.UserSSHKey, error) {
+	parsed, comment, _, _, err := ssh.ParseAuthorizedKey([]byte(publicKey))
+	if err != nil {
+		return nil, errInvalidPublicKey
+	}
+	if name == "" {
+		name = comment
+	}
+	key := &database.UserSSHKey{
+		UserID:      userID,
+		Name:        name,
+		PublicKey:   strings.TrimSpace(string(ssh.MarshalAuthorizedKey(parsed))),
+		Fingerprint: ssh.FingerprintSHA256(parsed),
+	}
+	if err := database.CreateUserSSHKey(key); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
+func isDuplicateKeyError(err error) bool {
+	if errors.Is(err, gorm.ErrDuplicatedKey) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "unique") || strings.Contains(msg, "duplicate")
+}
+
+// ListUserSSHKeys returns the current user's registered SSH keys.
+func ListUserSSHKeys(w http.ResponseWriter, r *http.Request) {
+	user := middleware.GetUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+
+	keys, err := database.ListUserSSHKeys(user.ID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "Failed to list keys")
+		return
+	}
+	result := make([]userSSHKeyResponse, 0, len(keys))
+	for _, k := range keys {
+		result = append(result, toUserSSHKeyResponse(k))
+	}
+	writeJSON(w, http.StatusOK, result)
+}
+
+// DeleteUserSSHKey revokes one of the current user's SSH keys.
+func DeleteUserSSHKey(w http.ResponseWriter, r *http.Request) {
+	user := middleware.GetUser(r)
+	if user == nil {
+		writeError(w, http.StatusUnauthorized, "Authentication required")
+		return
+	}
+
+	keyID, err := strconv.ParseUint(chi.URLParam(r, "keyId"), 10, 64)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "Invalid key ID")
+		return
+	}
+
+	if err := database.DeleteUserSSHKey(user.ID, uint(keyID)); err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			writeError(w, http.StatusNotFound, "Key not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "Failed to delete key")
+		return
+	}
+
+	if AuditLog != nil {
+		AuditLog.Log(sshaudit.EventKeyRotation, 0, user.Username, fmt.Sprintf("gateway key %d revoked", keyID))
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetSSHGatewayInfo reports the gateway's connection parameters for the UI.
+func GetSSHGatewayInfo(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"enabled": config.Cfg.SSHGatewayEnabled,
+		"port":    config.Cfg.SSHGatewayPort,
+		"host":    config.Cfg.SSHGatewayPublicHost,
+	})
+}
+
+func auditKeyEvent(username, action string, key *database.UserSSHKey) {
+	if AuditLog != nil {
+		AuditLog.Log(sshaudit.EventKeyUpload, 0, username,
+			fmt.Sprintf("gateway key %s: %s", action, key.Fingerprint))
+	}
+}

--- a/control-plane/internal/handlers/user_ssh_keys_test.go
+++ b/control-plane/internal/handlers/user_ssh_keys_test.go
@@ -1,0 +1,179 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gluk-w/claworc/control-plane/internal/database"
+	"github.com/gluk-w/claworc/control-plane/internal/middleware"
+	"github.com/gluk-w/claworc/control-plane/internal/sshproxy"
+)
+
+func setupSSHKeyTest(t *testing.T) *database.User {
+	t.Helper()
+	setupTestDB(t)
+	if err := database.DB.AutoMigrate(&database.UserSSHKey{}); err != nil {
+		t.Fatalf("migrate UserSSHKey: %v", err)
+	}
+	user := &database.User{Username: "alice", PasswordHash: "x", Role: "user"}
+	if err := database.CreateUser(user); err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	return user
+}
+
+func asUser(req *http.Request, user *database.User) *http.Request {
+	return req.WithContext(middleware.WithUser(req.Context(), user))
+}
+
+func TestGenerateUserSSHKey(t *testing.T) {
+	user := setupSSHKeyTest(t)
+
+	w := httptest.NewRecorder()
+	GenerateUserSSHKey(w, asUser(postJSON("/api/v1/auth/ssh-keys/generate", map[string]string{"name": "laptop"}), user))
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Key        userSSHKeyResponse `json:"key"`
+		PrivateKey string             `json:"private_key"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.Contains(resp.PrivateKey, "PRIVATE KEY") {
+		t.Error("expected PEM private key in response")
+	}
+	if resp.Key.Name != "laptop" || !strings.HasPrefix(resp.Key.Fingerprint, "SHA256:") {
+		t.Errorf("unexpected key metadata: %+v", resp.Key)
+	}
+
+	// The private key must be usable and match the stored public key.
+	signer, err := ssh.ParsePrivateKey([]byte(resp.PrivateKey))
+	if err != nil {
+		t.Fatalf("returned private key does not parse: %v", err)
+	}
+	stored, err := database.GetUserSSHKeyByFingerprint(ssh.FingerprintSHA256(signer.PublicKey()))
+	if err != nil {
+		t.Fatalf("stored key not found by fingerprint: %v", err)
+	}
+	if stored.UserID != user.ID {
+		t.Errorf("stored key user = %d, want %d", stored.UserID, user.ID)
+	}
+	// The private key must never be stored.
+	if strings.Contains(stored.PublicKey, "PRIVATE") {
+		t.Error("private key material stored in DB")
+	}
+}
+
+func TestUploadUserSSHKey(t *testing.T) {
+	user := setupSSHKeyTest(t)
+
+	pubKey, _, err := sshproxy.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+
+	w := httptest.NewRecorder()
+	UploadUserSSHKey(w, asUser(postJSON("/api/v1/auth/ssh-keys", map[string]string{
+		"name": "mykey", "public_key": string(pubKey),
+	}), user))
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201: %s", w.Code, w.Body.String())
+	}
+
+	// Duplicate upload → 409.
+	w = httptest.NewRecorder()
+	UploadUserSSHKey(w, asUser(postJSON("/api/v1/auth/ssh-keys", map[string]string{
+		"public_key": string(pubKey),
+	}), user))
+	if w.Code != http.StatusConflict {
+		t.Fatalf("duplicate status = %d, want 409: %s", w.Code, w.Body.String())
+	}
+
+	// Garbage → 400.
+	w = httptest.NewRecorder()
+	UploadUserSSHKey(w, asUser(postJSON("/api/v1/auth/ssh-keys", map[string]string{
+		"public_key": "not a key",
+	}), user))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid key status = %d, want 400", w.Code)
+	}
+}
+
+func TestListUserSSHKeys(t *testing.T) {
+	user := setupSSHKeyTest(t)
+
+	w := httptest.NewRecorder()
+	GenerateUserSSHKey(w, asUser(postJSON("/api/v1/auth/ssh-keys/generate", nil), user))
+
+	w = httptest.NewRecorder()
+	ListUserSSHKeys(w, asUser(httptest.NewRequest("GET", "/api/v1/auth/ssh-keys", nil), user))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var keys []userSSHKeyResponse
+	json.Unmarshal(w.Body.Bytes(), &keys)
+	if len(keys) != 1 {
+		t.Fatalf("listed %d keys, want 1", len(keys))
+	}
+}
+
+func deleteKeyRequest(keyID uint) *http.Request {
+	req := httptest.NewRequest("DELETE", fmt.Sprintf("/api/v1/auth/ssh-keys/%d", keyID), nil)
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("keyId", fmt.Sprintf("%d", keyID))
+	return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+}
+
+func TestDeleteUserSSHKey(t *testing.T) {
+	user := setupSSHKeyTest(t)
+
+	key := &database.UserSSHKey{UserID: user.ID, PublicKey: "k", Fingerprint: "SHA256:abc"}
+	if err := database.CreateUserSSHKey(key); err != nil {
+		t.Fatalf("create key: %v", err)
+	}
+
+	// Another user cannot delete it.
+	other := &database.User{Username: "bob", PasswordHash: "x", Role: "user"}
+	database.CreateUser(other)
+	w := httptest.NewRecorder()
+	DeleteUserSSHKey(w, asUser(deleteKeyRequest(key.ID), other))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("cross-user delete status = %d, want 404", w.Code)
+	}
+
+	// Owner can.
+	w = httptest.NewRecorder()
+	DeleteUserSSHKey(w, asUser(deleteKeyRequest(key.ID), user))
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("owner delete status = %d, want 204", w.Code)
+	}
+	if keys, _ := database.ListUserSSHKeys(user.ID); len(keys) != 0 {
+		t.Errorf("key still present after delete")
+	}
+}
+
+func TestGetSSHGatewayInfo(t *testing.T) {
+	w := httptest.NewRecorder()
+	GetSSHGatewayInfo(w, httptest.NewRequest("GET", "/api/v1/ssh-gateway/info", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var info map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &info)
+	for _, field := range []string{"enabled", "port", "host"} {
+		if _, ok := info[field]; !ok {
+			t.Errorf("missing field %q in %v", field, info)
+		}
+	}
+}

--- a/control-plane/internal/middleware/auth.go
+++ b/control-plane/internal/middleware/auth.go
@@ -134,26 +134,5 @@ func WithUser(ctx context.Context, user *database.User) context.Context {
 }
 
 func CanAccessInstance(r *http.Request, instanceID uint) bool {
-	user := GetUser(r)
-	if user == nil {
-		return false
-	}
-	if user.Role == "admin" {
-		return true
-	}
-	// Look up the instance's team. Managers of that team have access to
-	// all team instances. Regular team members still need an explicit
-	// UserInstance grant.
-	inst, err := database.GetInstance(instanceID)
-	if err == nil {
-		role := database.GetTeamRole(user.ID, inst.TeamID)
-		if role == database.TeamRoleManager {
-			return true
-		}
-		if role == database.TeamRoleUser && database.IsUserAssignedToInstance(user.ID, instanceID) {
-			return true
-		}
-		return false
-	}
-	return database.IsUserAssignedToInstance(user.ID, instanceID)
+	return database.CanUserAccessInstance(GetUser(r), instanceID)
 }

--- a/control-plane/internal/sshaudit/audit.go
+++ b/control-plane/internal/sshaudit/audit.go
@@ -29,6 +29,12 @@ const (
 	EventTerminalSession EventType = "terminal_session"
 	EventKeyUpload       EventType = "key_upload"
 	EventKeyRotation     EventType = "key_rotation"
+
+	// Inbound SSH gateway events (user -> control plane -> instance).
+	EventGatewayLogin       EventType = "gateway_login"
+	EventGatewayLoginFailed EventType = "gateway_login_failed"
+	EventGatewaySession     EventType = "gateway_session"
+	EventGatewayDisconnect  EventType = "gateway_disconnection"
 )
 
 // AuditEntry is the GORM model for the ssh_audit_logs table.

--- a/control-plane/internal/sshgateway/auth.go
+++ b/control-plane/internal/sshgateway/auth.go
@@ -1,0 +1,132 @@
+// auth.go authenticates inbound SSH connections against per-user public
+// keys and authorizes access to the requested instance.
+//
+// Authorization failures for a *valid* key are "soft": the connection is
+// accepted and the failure reason is stashed in Permissions.Extensions so
+// the session channel can print an actionable message (a hard reject would
+// only show the client an opaque "Permission denied (publickey)").
+
+package sshgateway
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gluk-w/claworc/control-plane/internal/database"
+	"github.com/gluk-w/claworc/control-plane/internal/sshaudit"
+)
+
+// Permissions.Extensions keys set by authenticate.
+const (
+	extUserID     = "claworc-user-id"
+	extUsername   = "claworc-username"
+	extKeyID      = "claworc-key-id"
+	extInstanceID = "claworc-instance-id" // set only when access is authorized
+	extDenyReason = "claworc-deny-reason" // denyMissingInstance | denyUnknownInstance
+)
+
+const (
+	denyMissingInstance = "missing-instance"
+	// denyUnknownInstance covers both "no such instance" and "not authorized"
+	// so authenticated users cannot enumerate instance names.
+	denyUnknownInstance = "unknown-instance"
+)
+
+var errAuthFailed = errors.New("unknown user or key")
+
+func (g *Gateway) authenticate(cm ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+	username, instancePart := ParseSSHUser(cm.User())
+	if username == "" {
+		return nil, errAuthFailed
+	}
+
+	user, err := database.GetUserByUsername(username)
+	if err != nil {
+		return nil, errAuthFailed
+	}
+
+	fingerprint := ssh.FingerprintSHA256(key)
+	k, err := database.GetUserSSHKeyByFingerprint(fingerprint)
+	if err != nil || k.UserID != user.ID {
+		return nil, errAuthFailed
+	}
+	// Never trust the fingerprint alone: require byte equality with the
+	// stored public key.
+	storedKey, _, _, _, err := ssh.ParseAuthorizedKey([]byte(k.PublicKey))
+	if err != nil || !bytes.Equal(storedKey.Marshal(), key.Marshal()) {
+		return nil, errAuthFailed
+	}
+
+	g.limiter.RecordSuccess(hostOnly(cm.RemoteAddr()))
+	database.TouchUserSSHKeyUsed(k.ID)
+
+	perms := &ssh.Permissions{Extensions: map[string]string{
+		extUserID:   strconv.FormatUint(uint64(user.ID), 10),
+		extUsername: user.Username,
+		extKeyID:    strconv.FormatUint(uint64(k.ID), 10),
+	}}
+
+	instanceID, denyReason := g.authorizeInstance(user, instancePart)
+	if denyReason != "" {
+		perms.Extensions[extDenyReason] = denyReason
+	} else {
+		perms.Extensions[extInstanceID] = strconv.FormatUint(uint64(instanceID), 10)
+	}
+
+	g.audit(sshaudit.EventGatewayLogin, instanceID, user.Username,
+		fmt.Sprintf("remote=%s key=%s instance=%q deny=%q",
+			hostOnly(cm.RemoteAddr()), fingerprint, instancePart, denyReason))
+	return perms, nil
+}
+
+// authorizeInstance resolves the instance part of the login name and checks
+// the user's access. Returns the instance ID on success, or a deny reason.
+func (g *Gateway) authorizeInstance(user *database.User, instancePart string) (uint, string) {
+	candidates := ResolveInstanceName(instancePart)
+	if len(candidates) == 0 {
+		return 0, denyMissingInstance
+	}
+	for _, name := range candidates {
+		inst, err := database.GetInstanceByName(name)
+		if err != nil {
+			continue
+		}
+		if database.CanUserAccessInstance(user, inst.ID) {
+			return inst.ID, ""
+		}
+		break // found but not authorized; render same as unknown
+	}
+	return 0, denyUnknownInstance
+}
+
+// accessibleInstanceNames lists the display-friendly instance names the user
+// may connect to (capped), for the missing-instance help message.
+func accessibleInstanceNames(userID uint, isAdmin bool) []string {
+	const maxNames = 20
+	var instances []database.Instance
+	if isAdmin {
+		if err := database.DB.Order("name").Limit(maxNames).Find(&instances).Error; err != nil {
+			return nil
+		}
+	} else {
+		ids, err := database.AccessibleInstanceIDs(userID)
+		if err != nil || len(ids) == 0 {
+			return nil
+		}
+		if err := database.DB.Where("id IN ?", ids).Order("name").Limit(maxNames).Find(&instances).Error; err != nil {
+			return nil
+		}
+	}
+	names := make([]string, 0, len(instances))
+	for _, inst := range instances {
+		names = append(names, strings.TrimPrefix(inst.Name, "bot-"))
+	}
+	sort.Strings(names)
+	return names
+}

--- a/control-plane/internal/sshgateway/auth_test.go
+++ b/control-plane/internal/sshgateway/auth_test.go
@@ -1,0 +1,182 @@
+package sshgateway
+
+import (
+	"net"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+
+	"github.com/gluk-w/claworc/control-plane/internal/database"
+	"github.com/gluk-w/claworc/control-plane/internal/database/migrations"
+	"github.com/gluk-w/claworc/control-plane/internal/sshproxy"
+)
+
+func setupTestDB(t *testing.T) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	if err != nil {
+		t.Fatalf("open in-memory db: %v", err)
+	}
+	// A pooled second connection to ":memory:" would see a fresh empty
+	// database; force a single connection so concurrent queries share it.
+	if sqlDB, err := db.DB(); err == nil {
+		sqlDB.SetMaxOpenConns(1)
+	}
+	if err := migrations.AutoMigrateAll(db); err != nil {
+		t.Fatalf("auto-migrate: %v", err)
+	}
+	database.DB = db
+	t.Cleanup(func() { database.DB = nil })
+}
+
+// generateUserKey creates a key pair, registers the public key for the user,
+// and returns the signer for authenticating.
+func generateUserKey(t *testing.T, userID uint) ssh.Signer {
+	t.Helper()
+	pubKey, privKeyPEM, err := sshproxy.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate key pair: %v", err)
+	}
+	signer, err := ssh.ParsePrivateKey(privKeyPEM)
+	if err != nil {
+		t.Fatalf("parse private key: %v", err)
+	}
+	parsed, _, _, _, err := ssh.ParseAuthorizedKey(pubKey)
+	if err != nil {
+		t.Fatalf("parse public key: %v", err)
+	}
+	if err := database.CreateUserSSHKey(&database.UserSSHKey{
+		UserID:      userID,
+		PublicKey:   string(pubKey),
+		Fingerprint: ssh.FingerprintSHA256(parsed),
+	}); err != nil {
+		t.Fatalf("create user ssh key: %v", err)
+	}
+	return signer
+}
+
+type fakeConnMetadata struct {
+	user string
+}
+
+func (m fakeConnMetadata) User() string          { return m.user }
+func (m fakeConnMetadata) SessionID() []byte     { return nil }
+func (m fakeConnMetadata) ClientVersion() []byte { return nil }
+func (m fakeConnMetadata) ServerVersion() []byte { return nil }
+func (m fakeConnMetadata) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 12345}
+}
+func (m fakeConnMetadata) LocalAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 2222}
+}
+
+func seedUser(t *testing.T, username, role string) *database.User {
+	t.Helper()
+	u := &database.User{Username: username, PasswordHash: "x", Role: role}
+	if err := database.CreateUser(u); err != nil {
+		t.Fatalf("create user %s: %v", username, err)
+	}
+	return u
+}
+
+func seedInstance(t *testing.T, name string, teamID uint) *database.Instance {
+	t.Helper()
+	inst := &database.Instance{Name: name, DisplayName: name, TeamID: teamID}
+	if err := database.DB.Create(inst).Error; err != nil {
+		t.Fatalf("create instance %s: %v", name, err)
+	}
+	return inst
+}
+
+func authPubKey(t *testing.T, signer ssh.Signer) ssh.PublicKey {
+	t.Helper()
+	return signer.PublicKey()
+}
+
+func TestAuthenticate(t *testing.T) {
+	setupTestDB(t)
+	g := New(Config{})
+
+	team := &database.Team{Name: "team-a"}
+	if err := database.DB.Create(team).Error; err != nil {
+		t.Fatalf("create team: %v", err)
+	}
+
+	admin := seedUser(t, "admin", "admin")
+	manager := seedUser(t, "manager", "user")
+	member := seedUser(t, "member", "user")
+	stranger := seedUser(t, "stranger", "user")
+
+	database.DB.Create(&database.TeamMember{TeamID: team.ID, UserID: manager.ID, Role: database.TeamRoleManager})
+	database.DB.Create(&database.TeamMember{TeamID: team.ID, UserID: member.ID, Role: database.TeamRoleUser})
+	database.DB.Create(&database.TeamMember{TeamID: team.ID, UserID: stranger.ID, Role: database.TeamRoleUser})
+
+	inst := seedInstance(t, "bot-my-agent", team.ID)
+	database.DB.Create(&database.UserInstance{UserID: member.ID, InstanceID: inst.ID})
+
+	adminKey := generateUserKey(t, admin.ID)
+	managerKey := generateUserKey(t, manager.ID)
+	memberKey := generateUserKey(t, member.ID)
+	strangerKey := generateUserKey(t, stranger.ID)
+
+	tests := []struct {
+		name       string
+		sshUser    string
+		signer     ssh.Signer
+		wantErr    bool
+		wantDeny   string
+		wantInstID bool
+	}{
+		{"admin full access", "admin+my-agent", adminKey, false, "", true},
+		{"admin with bot prefix", "admin+bot-my-agent", adminKey, false, "", true},
+		{"team manager", "manager+my-agent", managerKey, false, "", true},
+		{"granted member", "member+my-agent", memberKey, false, "", true},
+		{"ungranted team user", "stranger+my-agent", strangerKey, false, denyUnknownInstance, false},
+		{"unknown instance", "admin+nope", adminKey, false, denyUnknownInstance, false},
+		{"missing instance", "admin", adminKey, false, denyMissingInstance, false},
+		{"unknown user", "ghost+my-agent", adminKey, true, "", false},
+		{"wrong user's key", "admin+my-agent", strangerKey, true, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			perms, err := g.authenticate(fakeConnMetadata{user: tt.sshUser}, authPubKey(t, tt.signer))
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected authentication error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("authenticate: %v", err)
+			}
+			if got := perms.Extensions[extDenyReason]; got != tt.wantDeny {
+				t.Errorf("deny reason = %q, want %q", got, tt.wantDeny)
+			}
+			if hasInst := perms.Extensions[extInstanceID] != ""; hasInst != tt.wantInstID {
+				t.Errorf("instance ID set = %v, want %v", hasInst, tt.wantInstID)
+			}
+		})
+	}
+}
+
+func TestAuthenticateUnregisteredKey(t *testing.T) {
+	setupTestDB(t)
+	g := New(Config{})
+	seedUser(t, "alice", "admin")
+
+	_, privKeyPEM, err := sshproxy.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate key pair: %v", err)
+	}
+	signer, _ := ssh.ParsePrivateKey(privKeyPEM)
+
+	if _, err := g.authenticate(fakeConnMetadata{user: "alice+x"}, signer.PublicKey()); err == nil {
+		t.Fatal("expected error for unregistered key")
+	}
+}

--- a/control-plane/internal/sshgateway/bridge.go
+++ b/control-plane/internal/sshgateway/bridge.go
@@ -1,0 +1,280 @@
+// bridge.go splices an authenticated inbound SSH connection onto the
+// control plane's existing outbound SSH connection to the target instance.
+// Each inbound "session" channel becomes one new channel on the shared
+// per-instance *ssh.Client — never a new TCP/SSH connection.
+
+package sshgateway
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gluk-w/claworc/control-plane/internal/database"
+	"github.com/gluk-w/claworc/control-plane/internal/sshaudit"
+)
+
+func (g *Gateway) handleConn(nc net.Conn) {
+	nc.SetDeadline(time.Now().Add(handshakeTimeout))
+	sc, chans, reqs, err := ssh.NewServerConn(nc, g.serverConfig())
+	if err != nil {
+		nc.Close()
+		return
+	}
+	nc.SetDeadline(time.Time{})
+	defer sc.Close()
+	g.serveConn(sc, chans, reqs)
+}
+
+func (g *Gateway) serveConn(sc *ssh.ServerConn, chans <-chan ssh.NewChannel, reqs <-chan *ssh.Request) {
+	// Global requests (tcpip-forward, client keepalives, ...) are refused;
+	// only session channels are supported in v1.
+	go ssh.DiscardRequests(reqs)
+
+	username := sc.Permissions.Extensions[extUsername]
+	instanceID := permsUint(sc.Permissions, extInstanceID)
+
+	// connDone closes when the inbound connection is gone (client disconnect
+	// or gateway shutdown). Bridged sessions use it to tear down their
+	// instance-side channel so nothing leaks on the shared client.
+	connDone := make(chan struct{})
+	go func() { sc.Wait(); close(connDone) }()
+	stopWatch := make(chan struct{})
+	go func() {
+		select {
+		case <-g.ctx.Done():
+			sc.Close()
+		case <-stopWatch:
+		}
+	}()
+	defer close(stopWatch)
+
+	var wg sync.WaitGroup
+	for nc := range chans {
+		if nc.ChannelType() != "session" {
+			nc.Reject(ssh.Prohibited, "only sessions are supported by the claworc gateway")
+			continue
+		}
+		wg.Add(1)
+		go func(nc ssh.NewChannel) {
+			defer wg.Done()
+			g.handleSession(sc, nc, connDone)
+		}(nc)
+	}
+	wg.Wait()
+	g.audit(sshaudit.EventGatewayDisconnect, instanceID, username,
+		fmt.Sprintf("remote=%s", hostOnly(sc.RemoteAddr())))
+}
+
+func (g *Gateway) handleSession(sc *ssh.ServerConn, nc ssh.NewChannel, connDone <-chan struct{}) {
+	in, inReqs, err := nc.Accept()
+	if err != nil {
+		return
+	}
+	defer in.Close()
+
+	if reason := sc.Permissions.Extensions[extDenyReason]; reason != "" {
+		g.denySession(sc, in, inReqs, reason)
+		return
+	}
+
+	username := sc.Permissions.Extensions[extUsername]
+	instanceID := permsUint(sc.Permissions, extInstanceID)
+	inst, err := database.GetInstance(instanceID)
+	if err != nil {
+		failSession(in, inReqs, "claworc: instance no longer exists")
+		return
+	}
+
+	client, err := g.cfg.Clients(g.ctx, inst)
+	if err != nil {
+		log.Printf("SSH gateway: connect to instance %d failed: %v", instanceID, err)
+		failSession(in, inReqs, "claworc: instance not reachable")
+		return
+	}
+
+	// Raw channel on the shared multiplexed client. Never close the client
+	// itself — it is owned by SSHManager and shared with tunnels and web
+	// terminals.
+	out, outReqs, err := client.OpenChannel("session", nil)
+	if err != nil {
+		log.Printf("SSH gateway: open channel to instance %d failed: %v", instanceID, err)
+		failSession(in, inReqs, "claworc: instance not reachable")
+		return
+	}
+	defer out.Close()
+
+	g.bridgeChannels(in, inReqs, out, outReqs, instanceID, username, connDone)
+}
+
+// bridgeChannels pipes data and channel requests between the user's channel
+// (in) and the instance-side channel (out) until both close.
+func (g *Gateway) bridgeChannels(in ssh.Channel, inReqs <-chan *ssh.Request, out ssh.Channel, outReqs <-chan *ssh.Request, instanceID uint, username string, connDone <-chan struct{}) {
+	// If the inbound connection dies while the remote process is still
+	// running, force-close the instance-side channel; otherwise the
+	// exit-status drain below would wait forever and leak the channel on
+	// the shared client.
+	bridgeDone := make(chan struct{})
+	defer close(bridgeDone)
+	go func() {
+		select {
+		case <-connDone:
+			out.Close()
+		case <-bridgeDone:
+		}
+	}()
+
+	// Client-originated requests, forwarded to the instance sshd.
+	// pendingReqs tracks requests received but not yet replied to: a fast
+	// remote can emit output + exit-status and close before SendRequest for
+	// the triggering exec/shell even returns, and closing the inbound
+	// channel before its Reply is sent makes the client fail with EOF.
+	var pendingReqs sync.WaitGroup
+	go func() {
+		audited := false
+		for req := range inReqs {
+			pendingReqs.Add(1)
+			switch req.Type {
+			case "pty-req", "shell", "exec", "subsystem", "env",
+				"window-change", "signal", "eow@openssh.com", "break":
+				if !audited && (req.Type == "shell" || req.Type == "exec" || req.Type == "subsystem") {
+					audited = true
+					g.audit(sshaudit.EventGatewaySession, instanceID, username, sessionDetails(req))
+				}
+				ok, _ := out.SendRequest(req.Type, req.WantReply, req.Payload)
+				if req.WantReply {
+					req.Reply(ok, nil)
+				}
+			default:
+				if req.WantReply {
+					req.Reply(false, nil)
+				}
+			}
+			pendingReqs.Done()
+		}
+	}()
+
+	// Instance-originated requests (exit-status, exit-signal, eow) forwarded
+	// to the client. exitForwarded closing means outReqs drained, i.e. the
+	// exit-status has been relayed — only then is it safe to close `in`,
+	// otherwise the client would see exit code -1/255.
+	exitForwarded := make(chan struct{})
+	go func() {
+		defer close(exitForwarded)
+		for req := range outReqs {
+			ok, _ := in.SendRequest(req.Type, req.WantReply, req.Payload)
+			if req.WantReply {
+				req.Reply(ok, nil)
+			}
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); io.Copy(in, out) }()                   // stdout
+	go func() { defer wg.Done(); io.Copy(in.Stderr(), out.Stderr()) }() // stderr
+	go func() {
+		io.Copy(out, in) // stdin; propagate client-side EOF
+		out.CloseWrite()
+	}()
+
+	wg.Wait()
+	<-exitForwarded
+	pendingReqs.Wait()
+}
+
+// denySession handles a session whose key authenticated but whose instance
+// selection was rejected: print an actionable message, list the agents the
+// user may connect to as ready-to-copy login names, and exit non-zero.
+// Listing only the user's own accessible instances leaks nothing they
+// cannot already see in the dashboard.
+func (g *Gateway) denySession(sc *ssh.ServerConn, in ssh.Channel, inReqs <-chan *ssh.Request, reason string) {
+	username := sc.Permissions.Extensions[extUsername]
+	msg := "claworc: instance not found or not authorized\r\n"
+	if reason == denyMissingInstance {
+		msg = fmt.Sprintf("claworc: no instance specified. Connect as %s+<instance-name>@<host>\r\n", username)
+	}
+
+	userID := permsUint(sc.Permissions, extUserID)
+	if user, err := database.GetUserByID(userID); err == nil {
+		if names := accessibleInstanceNames(userID, user.Role == "admin"); len(names) > 0 {
+			msg += "\r\nYour agents:\r\n"
+			for _, name := range names {
+				msg += fmt.Sprintf("  %s+%s\r\n", username, name)
+			}
+		}
+	}
+	failSession(in, inReqs, strings.TrimSuffix(msg, "\r\n"))
+}
+
+// failSession lets the client attach (accepting pty/shell requests), prints
+// a message, and terminates with exit status 1.
+func failSession(in ssh.Channel, inReqs <-chan *ssh.Request, msg string) {
+	started := make(chan struct{})
+	var once sync.Once
+	go func() {
+		// Also unblocks the wait below if the client disconnects before
+		// ever requesting a shell/exec.
+		defer once.Do(func() { close(started) })
+		for req := range inReqs {
+			if req.WantReply {
+				req.Reply(true, nil)
+			}
+			switch req.Type {
+			case "shell", "exec", "subsystem":
+				once.Do(func() { close(started) })
+			}
+		}
+	}()
+	<-started
+	io.WriteString(in, msg+"\r\n")
+	in.SendRequest("exit-status", false, exitStatusPayload(1))
+	in.CloseWrite()
+}
+
+func sessionDetails(req *ssh.Request) string {
+	switch req.Type {
+	case "exec", "subsystem":
+		name := parseSSHString(req.Payload)
+		if len(name) > 200 {
+			name = name[:200] + "..."
+		}
+		return req.Type + ":" + name
+	default:
+		return req.Type
+	}
+}
+
+// parseSSHString decodes a length-prefixed SSH string (RFC 4251).
+func parseSSHString(payload []byte) string {
+	if len(payload) < 4 {
+		return ""
+	}
+	n := binary.BigEndian.Uint32(payload)
+	if uint32(len(payload)-4) < n {
+		return ""
+	}
+	return string(payload[4 : 4+n])
+}
+
+func exitStatusPayload(code uint32) []byte {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, code)
+	return b
+}
+
+func permsUint(perms *ssh.Permissions, key string) uint {
+	if perms == nil {
+		return 0
+	}
+	n, _ := strconv.ParseUint(perms.Extensions[key], 10, 64)
+	return uint(n)
+}

--- a/control-plane/internal/sshgateway/bridge.go
+++ b/control-plane/internal/sshgateway/bridge.go
@@ -275,6 +275,6 @@ func permsUint(perms *ssh.Permissions, key string) uint {
 	if perms == nil {
 		return 0
 	}
-	n, _ := strconv.ParseUint(perms.Extensions[key], 10, 64)
+	n, _ := strconv.ParseUint(perms.Extensions[key], 10, 32)
 	return uint(n)
 }

--- a/control-plane/internal/sshgateway/gateway.go
+++ b/control-plane/internal/sshgateway/gateway.go
@@ -1,0 +1,169 @@
+// Package sshgateway implements the inbound SSH gateway: users connect with
+// `ssh <username>+<instance>@<claworc-host>`, authenticate with a per-user
+// public key registered in Claworc, and their session is bridged onto the
+// control plane's existing multiplexed SSH connection to the target instance.
+// The gateway never dials its own connection to an agent — it only opens new
+// channels on the shared per-instance client owned by sshproxy.SSHManager.
+package sshgateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gluk-w/claworc/control-plane/internal/database"
+	"github.com/gluk-w/claworc/control-plane/internal/sshaudit"
+)
+
+const handshakeTimeout = 30 * time.Second
+
+// ClientProvider returns a live multiplexed outbound SSH client for an
+// instance. The production implementation wraps
+// SSHManager.EnsureConnectedWithIPCheck so the existing per-instance
+// connection (already carrying tunnels and web terminals) is reused.
+type ClientProvider func(ctx context.Context, inst *database.Instance) (*ssh.Client, error)
+
+// Config holds the gateway's dependencies.
+type Config struct {
+	Addr     string // listen address, e.g. ":2222"
+	HostKey  ssh.Signer
+	Clients  ClientProvider
+	Auditor  *sshaudit.Auditor
+	MaxConns int // max concurrent inbound connections; 0 = default 64
+}
+
+// Gateway is the inbound SSH server.
+type Gateway struct {
+	cfg      Config
+	ln       net.Listener
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	limiter  *ipLimiter
+	conns    atomic.Int64
+	maxConns int64
+}
+
+// New creates a Gateway. Call Start to begin accepting connections.
+func New(cfg Config) *Gateway {
+	maxConns := int64(cfg.MaxConns)
+	if maxConns <= 0 {
+		maxConns = 64
+	}
+	return &Gateway{cfg: cfg, limiter: newIPLimiter(), maxConns: maxConns}
+}
+
+// Start begins listening and serving in background goroutines.
+func (g *Gateway) Start(ctx context.Context) error {
+	ln, err := net.Listen("tcp", g.cfg.Addr)
+	if err != nil {
+		return fmt.Errorf("ssh gateway listen on %s: %w", g.cfg.Addr, err)
+	}
+	g.ln = ln
+	g.ctx, g.cancel = context.WithCancel(ctx)
+	log.Printf("SSH gateway listening on %s", ln.Addr())
+
+	g.wg.Add(1)
+	go func() {
+		defer g.wg.Done()
+		for {
+			nc, err := ln.Accept()
+			if err != nil {
+				if errors.Is(err, net.ErrClosed) || g.ctx.Err() != nil {
+					return
+				}
+				log.Printf("SSH gateway accept error: %v", err)
+				continue
+			}
+			if g.conns.Load() >= g.maxConns || !g.limiter.Allow(remoteIP(nc)) {
+				nc.Close()
+				continue
+			}
+			g.conns.Add(1)
+			g.wg.Add(1)
+			go func() {
+				defer g.wg.Done()
+				defer g.conns.Add(-1)
+				g.handleConn(nc)
+			}()
+		}
+	}()
+	return nil
+}
+
+// Stop closes the listener and waits briefly for in-flight connections.
+func (g *Gateway) Stop() {
+	if g.ln != nil {
+		g.ln.Close()
+	}
+	if g.cancel != nil {
+		g.cancel()
+	}
+	done := make(chan struct{})
+	go func() { g.wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		log.Printf("SSH gateway: shutdown timed out waiting for connections")
+	}
+}
+
+// Addr returns the bound listener address (useful with ":0" in tests).
+func (g *Gateway) Addr() net.Addr {
+	if g.ln == nil {
+		return nil
+	}
+	return g.ln.Addr()
+}
+
+func (g *Gateway) serverConfig() *ssh.ServerConfig {
+	cfg := &ssh.ServerConfig{
+		MaxAuthTries:      3,
+		ServerVersion:     "SSH-2.0-Claworc",
+		PublicKeyCallback: g.authenticate,
+		BannerCallback: func(cm ssh.ConnMetadata) string {
+			if _, instance := ParseSSHUser(cm.User()); instance == "" {
+				return "claworc: connect as <username>+<instance-name>@<host>\r\n"
+			}
+			return ""
+		},
+		AuthLogCallback: func(cm ssh.ConnMetadata, method string, err error) {
+			if err != nil && method == "publickey" {
+				ip := hostOnly(cm.RemoteAddr())
+				g.limiter.RecordFailure(ip)
+				g.audit(sshaudit.EventGatewayLoginFailed, 0, cm.User(),
+					fmt.Sprintf("remote=%s method=%s", ip, method))
+			}
+		},
+	}
+	cfg.AddHostKey(g.cfg.HostKey)
+	return cfg
+}
+
+func (g *Gateway) audit(event sshaudit.EventType, instanceID uint, user, details string) {
+	if g.cfg.Auditor != nil {
+		g.cfg.Auditor.Log(event, instanceID, user, details)
+	}
+}
+
+func remoteIP(nc net.Conn) string {
+	return hostOnly(nc.RemoteAddr())
+}
+
+func hostOnly(addr net.Addr) string {
+	if addr == nil {
+		return ""
+	}
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return addr.String()
+	}
+	return host
+}

--- a/control-plane/internal/sshgateway/gateway_test.go
+++ b/control-plane/internal/sshgateway/gateway_test.go
@@ -1,0 +1,416 @@
+package sshgateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gluk-w/claworc/control-plane/internal/database"
+	"github.com/gluk-w/claworc/control-plane/internal/sshproxy"
+)
+
+// fakeAgentSSHD is an in-process stand-in for an agent container's sshd.
+// It answers exec requests with "ran:<cmd>" and a parseable exit status,
+// and counts accepted TCP connections so tests can assert connection reuse.
+type fakeAgentSSHD struct {
+	addr      string
+	connCount atomic.Int64
+	cleanup   func()
+}
+
+func startFakeAgentSSHD(t *testing.T, authorizedKey ssh.PublicKey) *fakeAgentSSHD {
+	t.Helper()
+
+	_, hostKeyPEM, err := sshproxy.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate host key: %v", err)
+	}
+	hostSigner, err := ssh.ParsePrivateKey(hostKeyPEM)
+	if err != nil {
+		t.Fatalf("parse host key: %v", err)
+	}
+
+	cfg := &ssh.ServerConfig{
+		PublicKeyCallback: func(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+			if bytes.Equal(key.Marshal(), authorizedKey.Marshal()) {
+				return &ssh.Permissions{}, nil
+			}
+			return nil, fmt.Errorf("unknown public key")
+		},
+	}
+	cfg.AddHostKey(hostSigner)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	s := &fakeAgentSSHD{addr: ln.Addr().String()}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			nc, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			s.connCount.Add(1)
+			go s.handleConn(nc, cfg)
+		}
+	}()
+	s.cleanup = func() {
+		ln.Close()
+		<-done
+	}
+	return s
+}
+
+func (s *fakeAgentSSHD) handleConn(nc net.Conn, cfg *ssh.ServerConfig) {
+	conn, chans, reqs, err := ssh.NewServerConn(nc, cfg)
+	if err != nil {
+		nc.Close()
+		return
+	}
+	defer conn.Close()
+	go ssh.DiscardRequests(reqs)
+
+	for newChan := range chans {
+		if newChan.ChannelType() != "session" {
+			newChan.Reject(ssh.UnknownChannelType, "unknown channel type")
+			continue
+		}
+		ch, requests, err := newChan.Accept()
+		if err != nil {
+			continue
+		}
+		go s.handleSession(ch, requests)
+	}
+}
+
+func (s *fakeAgentSSHD) handleSession(ch ssh.Channel, requests <-chan *ssh.Request) {
+	defer ch.Close()
+	for req := range requests {
+		switch req.Type {
+		case "pty-req", "env", "window-change":
+			if req.WantReply {
+				req.Reply(true, nil)
+			}
+		case "shell":
+			if req.WantReply {
+				req.Reply(true, nil)
+			}
+			// Echo one line of stdin back, then exit 0.
+			buf := make([]byte, 4096)
+			n, _ := ch.Read(buf)
+			if n > 0 {
+				ch.Write([]byte("echo:"))
+				ch.Write(buf[:n])
+			}
+			sendExit(ch, 0)
+			return
+		case "exec":
+			if req.WantReply {
+				req.Reply(true, nil)
+			}
+			cmd := parseSSHString(req.Payload)
+			fmt.Fprintf(ch, "ran:%s\n", cmd)
+			code := uint32(0)
+			if strings.HasPrefix(cmd, "exit ") {
+				fmt.Sscanf(cmd, "exit %d", &code)
+			}
+			sendExit(ch, code)
+			return
+		default:
+			if req.WantReply {
+				req.Reply(false, nil)
+			}
+		}
+	}
+}
+
+func sendExit(ch ssh.Channel, code uint32) {
+	b := make([]byte, 4)
+	binary.BigEndian.PutUint32(b, code)
+	ch.SendRequest("exit-status", false, b)
+	ch.CloseWrite()
+}
+
+// testEnv wires DB, fake sshd, a shared outbound client, and a running gateway.
+type testEnv struct {
+	gw       *Gateway
+	sshd     *fakeAgentSSHD
+	signer   ssh.Signer // user's key, registered for "stan"
+	provided atomic.Int64
+}
+
+func setupGateway(t *testing.T) *testEnv {
+	t.Helper()
+	setupTestDB(t)
+
+	user := seedUser(t, "stan", "admin")
+	seedInstance(t, "bot-my-agent", 0)
+	userSigner := generateUserKey(t, user.ID)
+
+	// The control plane's outbound client identity.
+	_, cpKeyPEM, err := sshproxy.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate control-plane key: %v", err)
+	}
+	cpSigner, _ := ssh.ParsePrivateKey(cpKeyPEM)
+
+	sshd := startFakeAgentSSHD(t, cpSigner.PublicKey())
+	t.Cleanup(sshd.cleanup)
+
+	env := &testEnv{sshd: sshd, signer: userSigner}
+
+	// Shared outbound client, dialed lazily exactly once — mirrors
+	// SSHManager.EnsureConnected's reuse behavior.
+	var once sync.Once
+	var client *ssh.Client
+	var dialErr error
+	provider := func(ctx context.Context, inst *database.Instance) (*ssh.Client, error) {
+		env.provided.Add(1)
+		once.Do(func() {
+			client, dialErr = ssh.Dial("tcp", sshd.addr, &ssh.ClientConfig{
+				User:            "root",
+				Auth:            []ssh.AuthMethod{ssh.PublicKeys(cpSigner)},
+				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+				Timeout:         5 * time.Second,
+			})
+		})
+		return client, dialErr
+	}
+	t.Cleanup(func() {
+		if client != nil {
+			client.Close()
+		}
+	})
+
+	_, gwKeyPEM, err := sshproxy.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate gateway host key: %v", err)
+	}
+	gwSigner, _ := ssh.ParsePrivateKey(gwKeyPEM)
+
+	gw := New(Config{Addr: "127.0.0.1:0", HostKey: gwSigner, Clients: provider})
+	if err := gw.Start(context.Background()); err != nil {
+		t.Fatalf("start gateway: %v", err)
+	}
+	t.Cleanup(gw.Stop)
+	env.gw = gw
+	return env
+}
+
+func (e *testEnv) dial(t *testing.T, sshUser string, signer ssh.Signer) *ssh.Client {
+	t.Helper()
+	client, err := ssh.Dial("tcp", e.gw.Addr().String(), &ssh.ClientConfig{
+		User:            sshUser,
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("dial gateway as %q: %v", sshUser, err)
+	}
+	t.Cleanup(func() { client.Close() })
+	return client
+}
+
+func TestGatewayExecBridging(t *testing.T) {
+	env := setupGateway(t)
+	client := env.dial(t, "stan+my-agent", env.signer)
+
+	sess, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	defer sess.Close()
+
+	out, err := sess.Output("hostname")
+	if err != nil {
+		t.Fatalf("exec: %v", err)
+	}
+	if got := string(out); got != "ran:hostname\n" {
+		t.Errorf("exec output = %q, want %q", got, "ran:hostname\n")
+	}
+}
+
+func TestGatewayExitStatusForwarded(t *testing.T) {
+	env := setupGateway(t)
+	client := env.dial(t, "stan+my-agent", env.signer)
+
+	sess, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	defer sess.Close()
+
+	err = sess.Run("exit 7")
+	exitErr, ok := err.(*ssh.ExitError)
+	if !ok {
+		t.Fatalf("expected *ssh.ExitError, got %v", err)
+	}
+	if exitErr.ExitStatus() != 7 {
+		t.Errorf("exit status = %d, want 7", exitErr.ExitStatus())
+	}
+}
+
+func TestGatewayConnectionReuse(t *testing.T) {
+	env := setupGateway(t)
+	client := env.dial(t, "stan+my-agent", env.signer)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sess, err := client.NewSession()
+			if err != nil {
+				t.Errorf("new session: %v", err)
+				return
+			}
+			defer sess.Close()
+			if _, err := sess.Output("hostname"); err != nil {
+				t.Errorf("exec: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	// A second inbound SSH connection must also reuse the outbound one.
+	client2 := env.dial(t, "stan+my-agent", env.signer)
+	sess, err := client2.NewSession()
+	if err != nil {
+		t.Fatalf("new session on second connection: %v", err)
+	}
+	defer sess.Close()
+	if _, err := sess.Output("hostname"); err != nil {
+		t.Fatalf("exec on second connection: %v", err)
+	}
+
+	if got := env.sshd.connCount.Load(); got != 1 {
+		t.Errorf("agent sshd saw %d connections, want 1 (must reuse the existing SSH connection)", got)
+	}
+	if env.provided.Load() < 3 {
+		t.Errorf("provider called %d times, want >=3 (once per session)", env.provided.Load())
+	}
+}
+
+func TestGatewayWrongKeyRejected(t *testing.T) {
+	env := setupGateway(t)
+
+	_, otherPEM, _ := sshproxy.GenerateKeyPair()
+	otherSigner, _ := ssh.ParsePrivateKey(otherPEM)
+
+	_, err := ssh.Dial("tcp", env.gw.Addr().String(), &ssh.ClientConfig{
+		User:            "stan+my-agent",
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(otherSigner)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected authentication failure with unregistered key")
+	}
+}
+
+func TestGatewayMissingInstanceMessage(t *testing.T) {
+	env := setupGateway(t)
+	client := env.dial(t, "stan", env.signer)
+
+	sess, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	defer sess.Close()
+
+	out, err := sess.Output("whatever")
+	exitErr, ok := err.(*ssh.ExitError)
+	if !ok {
+		t.Fatalf("expected *ssh.ExitError, got %v (output %q)", err, out)
+	}
+	if exitErr.ExitStatus() != 1 {
+		t.Errorf("exit status = %d, want 1", exitErr.ExitStatus())
+	}
+	text := string(out)
+	if !strings.Contains(text, "no instance specified") {
+		t.Errorf("output %q should mention missing instance", text)
+	}
+	if !strings.Contains(text, "stan+my-agent") {
+		t.Errorf("output %q should list copyable login stan+my-agent", text)
+	}
+	if env.sshd.connCount.Load() != 0 {
+		t.Errorf("denied session must not touch the agent")
+	}
+}
+
+func TestGatewayUnknownInstance(t *testing.T) {
+	env := setupGateway(t)
+	client := env.dial(t, "stan+nope", env.signer)
+
+	sess, err := client.NewSession()
+	if err != nil {
+		t.Fatalf("new session: %v", err)
+	}
+	defer sess.Close()
+
+	out, err := sess.Output("x")
+	if _, ok := err.(*ssh.ExitError); !ok {
+		t.Fatalf("expected *ssh.ExitError, got %v", err)
+	}
+	if !strings.Contains(string(out), "not found or not authorized") {
+		t.Errorf("output %q should be the generic denial", string(out))
+	}
+	if !strings.Contains(string(out), "stan+my-agent") {
+		t.Errorf("output %q should list copyable login names", string(out))
+	}
+}
+
+func TestGatewayRejectsDirectTCPIP(t *testing.T) {
+	env := setupGateway(t)
+	client := env.dial(t, "stan+my-agent", env.signer)
+
+	// direct-tcpip open must be rejected (v1 supports sessions only).
+	if _, err := client.Dial("tcp", "127.0.0.1:80"); err == nil {
+		t.Fatal("expected direct-tcpip to be rejected")
+	}
+}
+
+func TestGatewayRateLimiterBansAfterFailures(t *testing.T) {
+	env := setupGateway(t)
+
+	_, otherPEM, _ := sshproxy.GenerateKeyPair()
+	otherSigner, _ := ssh.ParsePrivateKey(otherPEM)
+
+	cfg := &ssh.ClientConfig{
+		User:            "stan+my-agent",
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(otherSigner)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         5 * time.Second,
+	}
+	// Each dial burns up to MaxAuthTries failures; a handful trips the ban.
+	for i := 0; i < maxFailures; i++ {
+		ssh.Dial("tcp", env.gw.Addr().String(), cfg)
+	}
+
+	if env.gw.limiter.Allow("127.0.0.1") {
+		t.Fatal("expected 127.0.0.1 to be banned after repeated auth failures")
+	}
+	// Banned IPs are dropped at accept time even with the right key.
+	if _, err := ssh.Dial("tcp", env.gw.Addr().String(), &ssh.ClientConfig{
+		User:            "stan+my-agent",
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(env.signer)},
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Timeout:         2 * time.Second,
+	}); err == nil {
+		t.Fatal("expected banned IP to be refused")
+	}
+}

--- a/control-plane/internal/sshgateway/hostkey.go
+++ b/control-plane/internal/sshgateway/hostkey.go
@@ -1,0 +1,48 @@
+// hostkey.go manages the gateway's own SSH host key, distinct from the
+// control plane's client key pair in sshproxy (ssh_key/ssh_key.pub).
+
+package sshgateway
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/gluk-w/claworc/control-plane/internal/sshproxy"
+)
+
+const (
+	hostKeyFile    = "ssh_gateway_host_key"
+	hostKeyPubFile = "ssh_gateway_host_key.pub"
+)
+
+// EnsureHostKey loads the gateway's ED25519 host key from dir, generating
+// and persisting one on first run.
+func EnsureHostKey(dir string) (ssh.Signer, error) {
+	privPath := filepath.Join(dir, hostKeyFile)
+
+	if _, err := os.Stat(privPath); err != nil {
+		pubKey, privKey, err := sshproxy.GenerateKeyPair()
+		if err != nil {
+			return nil, fmt.Errorf("generate gateway host key: %w", err)
+		}
+		if err := os.WriteFile(privPath, privKey, 0600); err != nil {
+			return nil, fmt.Errorf("write gateway host key: %w", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, hostKeyPubFile), pubKey, 0644); err != nil {
+			return nil, fmt.Errorf("write gateway host public key: %w", err)
+		}
+	}
+
+	pemBytes, err := os.ReadFile(privPath)
+	if err != nil {
+		return nil, fmt.Errorf("read gateway host key: %w", err)
+	}
+	signer, err := ssh.ParsePrivateKey(pemBytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse gateway host key: %w", err)
+	}
+	return signer, nil
+}

--- a/control-plane/internal/sshgateway/openssh_compat_test.go
+++ b/control-plane/internal/sshgateway/openssh_compat_test.go
@@ -1,0 +1,123 @@
+package sshgateway
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"gorm.io/gorm"
+
+	"github.com/gluk-w/claworc/control-plane/internal/database"
+	"github.com/gluk-w/claworc/control-plane/internal/sshproxy"
+)
+
+// TestOpenSSHClientCompat drives the gateway with the real `ssh` binary to
+// catch protocol details the Go client tolerates but OpenSSH does not
+// (banner handling, exit-status ordering, request semantics).
+func TestOpenSSHClientCompat(t *testing.T) {
+	sshBin, err := exec.LookPath("ssh")
+	if err != nil {
+		t.Skip("ssh binary not available")
+	}
+
+	env := setupGateway(t)
+
+	// Write the user's private key where the ssh CLI can use it. The DB
+	// only has the registered public key; regenerate a matching PEM by
+	// creating a fresh key for the same user instead.
+	user, err := database.GetUserByUsername("stan")
+	if err != nil {
+		t.Fatalf("get user: %v", err)
+	}
+	// Same format users download from the profile page.
+	pubKey, privKeyPEM, err := sshproxy.GenerateOpenSSHKeyPair()
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	parsed, _, _, _, _ := ssh.ParseAuthorizedKey(pubKey)
+	if err := database.CreateUserSSHKey(&database.UserSSHKey{
+		UserID:      user.ID,
+		PublicKey:   string(pubKey),
+		Fingerprint: ssh.FingerprintSHA256(parsed),
+	}); err != nil {
+		t.Fatalf("register key: %v", err)
+	}
+
+	keyPath := filepath.Join(t.TempDir(), "id_claworc")
+	if err := os.WriteFile(keyPath, privKeyPEM, 0600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	host, port, err := net.SplitHostPort(env.gw.Addr().String())
+	if err != nil {
+		t.Fatalf("split addr: %v", err)
+	}
+
+	runSSH := func(loginUser, command string) (string, int) {
+		t.Helper()
+		cmd := exec.Command(sshBin,
+			"-i", keyPath,
+			"-p", port,
+			"-o", "StrictHostKeyChecking=no",
+			"-o", "UserKnownHostsFile=/dev/null",
+			"-o", "IdentitiesOnly=yes",
+			"-o", "BatchMode=yes",
+			fmt.Sprintf("%s@%s", loginUser, host),
+			command,
+		)
+		out, err := cmd.CombinedOutput()
+		code := 0
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			code = exitErr.ExitCode()
+		} else if err != nil {
+			t.Fatalf("ssh: %v (output %q)", err, out)
+		}
+		return string(out), code
+	}
+
+	t.Run("exec with exit 0", func(t *testing.T) {
+		out, code := runSSH("stan+my-agent", "hostname")
+		if code != 0 {
+			t.Errorf("exit code = %d, want 0 (output %q)", code, out)
+		}
+		if !strings.Contains(out, "ran:hostname") {
+			t.Errorf("output %q missing exec result", out)
+		}
+	})
+
+	t.Run("exit status forwarded", func(t *testing.T) {
+		_, code := runSSH("stan+my-agent", "exit 7")
+		if code != 7 {
+			t.Errorf("exit code = %d, want 7", code)
+		}
+	})
+
+	t.Run("missing instance help", func(t *testing.T) {
+		out, code := runSSH("stan", "true")
+		if code != 1 {
+			t.Errorf("exit code = %d, want 1 (output %q)", code, out)
+		}
+		if !strings.Contains(out, "no instance specified") || !strings.Contains(out, "my-agent") {
+			t.Errorf("output %q should explain and list instances", out)
+		}
+	})
+
+	t.Run("revoked key refused", func(t *testing.T) {
+		var key database.UserSSHKey
+		if err := database.DB.Where("fingerprint = ?", ssh.FingerprintSHA256(parsed)).First(&key).Error; err != nil {
+			t.Fatalf("find key: %v", err)
+		}
+		if err := database.DeleteUserSSHKey(user.ID, key.ID); err != nil && err != gorm.ErrRecordNotFound {
+			t.Fatalf("revoke: %v", err)
+		}
+		out, code := runSSH("stan+my-agent", "hostname")
+		if code == 0 {
+			t.Errorf("expected failure after key revocation (output %q)", out)
+		}
+	})
+}

--- a/control-plane/internal/sshgateway/parse.go
+++ b/control-plane/internal/sshgateway/parse.go
@@ -1,0 +1,31 @@
+// parse.go maps the SSH login name "user+instance" onto a Claworc username
+// and a target instance name.
+
+package sshgateway
+
+import "strings"
+
+// ParseSSHUser splits an SSH login name of the form "<username>+<instance>"
+// on the FIRST '+'. An empty instance means the client did not specify one.
+// Instance names are K8s-safe ([a-z0-9-]) and never contain '+'; Claworc
+// usernames containing '+' cannot use the gateway.
+func ParseSSHUser(sshUser string) (username, instance string) {
+	if i := strings.IndexByte(sshUser, '+'); i >= 0 {
+		return sshUser[:i], sshUser[i+1:]
+	}
+	return sshUser, ""
+}
+
+// ResolveInstanceName returns the candidate DB instance names for a
+// user-typed instance part, in lookup order. Instance names are stored with
+// a "bot-" prefix (see generateName), which users may omit.
+func ResolveInstanceName(raw string) []string {
+	name := strings.ToLower(strings.TrimSpace(raw))
+	if name == "" {
+		return nil
+	}
+	if strings.HasPrefix(name, "bot-") {
+		return []string{name}
+	}
+	return []string{name, "bot-" + name}
+}

--- a/control-plane/internal/sshgateway/parse_test.go
+++ b/control-plane/internal/sshgateway/parse_test.go
@@ -1,0 +1,49 @@
+package sshgateway
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseSSHUser(t *testing.T) {
+	tests := []struct {
+		in           string
+		wantUser     string
+		wantInstance string
+	}{
+		{"stan+my-agent", "stan", "my-agent"},
+		{"stan", "stan", ""},
+		{"stan+", "stan", ""},
+		{"+my-agent", "", "my-agent"},
+		{"stan+bot-my-agent", "stan", "bot-my-agent"},
+		{"a+b+c", "a", "b+c"},
+		{"", "", ""},
+	}
+	for _, tt := range tests {
+		user, instance := ParseSSHUser(tt.in)
+		if user != tt.wantUser || instance != tt.wantInstance {
+			t.Errorf("ParseSSHUser(%q) = (%q, %q), want (%q, %q)",
+				tt.in, user, instance, tt.wantUser, tt.wantInstance)
+		}
+	}
+}
+
+func TestResolveInstanceName(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string
+	}{
+		{"my-agent", []string{"my-agent", "bot-my-agent"}},
+		{"bot-my-agent", []string{"bot-my-agent"}},
+		{"My-Agent", []string{"my-agent", "bot-my-agent"}},
+		{"  my-agent  ", []string{"my-agent", "bot-my-agent"}},
+		{"", nil},
+		{"   ", nil},
+	}
+	for _, tt := range tests {
+		got := ResolveInstanceName(tt.in)
+		if !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("ResolveInstanceName(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}

--- a/control-plane/internal/sshgateway/ratelimit.go
+++ b/control-plane/internal/sshgateway/ratelimit.go
@@ -1,0 +1,72 @@
+// ratelimit.go provides brute-force protection for the gateway listener:
+// a per-IP failed-authentication limiter with a temporary ban.
+
+package sshgateway
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	maxFailures   = 10
+	failureWindow = time.Minute
+	banDuration   = 5 * time.Minute
+)
+
+type ipState struct {
+	failures    []time.Time
+	bannedUntil time.Time
+}
+
+type ipLimiter struct {
+	mu     sync.Mutex
+	states map[string]*ipState
+	now    func() time.Time // overridable for tests
+}
+
+func newIPLimiter() *ipLimiter {
+	return &ipLimiter{states: make(map[string]*ipState), now: time.Now}
+}
+
+// Allow reports whether the IP may attempt a connection.
+func (l *ipLimiter) Allow(ip string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	s, ok := l.states[ip]
+	if !ok {
+		return true
+	}
+	return l.now().After(s.bannedUntil)
+}
+
+// RecordFailure notes a failed authentication; too many within the window
+// bans the IP.
+func (l *ipLimiter) RecordFailure(ip string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	now := l.now()
+	s, ok := l.states[ip]
+	if !ok {
+		s = &ipState{}
+		l.states[ip] = s
+	}
+	recent := s.failures[:0]
+	for _, t := range s.failures {
+		if now.Sub(t) < failureWindow {
+			recent = append(recent, t)
+		}
+	}
+	s.failures = append(recent, now)
+	if len(s.failures) >= maxFailures {
+		s.bannedUntil = now.Add(banDuration)
+		s.failures = nil
+	}
+}
+
+// RecordSuccess clears the IP's failure history.
+func (l *ipLimiter) RecordSuccess(ip string) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	delete(l.states, ip)
+}

--- a/control-plane/internal/sshproxy/keys.go
+++ b/control-plane/internal/sshproxy/keys.go
@@ -52,6 +52,31 @@ func GenerateKeyPair() (publicKey, privateKeyPEM []byte, err error) {
 	return publicKey, privateKeyPEM, nil
 }
 
+// GenerateOpenSSHKeyPair generates an ED25519 key pair with the private key
+// in OpenSSH's native format ("OPENSSH PRIVATE KEY"). Use this for keys
+// handed to end users: the openssh client rejects PKCS#8 ed25519 keys
+// ("invalid format"), while ssh.ParsePrivateKey reads both.
+func GenerateOpenSSHKeyPair() (publicKey, privateKeyPEM []byte, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("generate ed25519 key: %w", err)
+	}
+
+	block, err := ssh.MarshalPrivateKey(priv, "")
+	if err != nil {
+		return nil, nil, fmt.Errorf("marshal private key: %w", err)
+	}
+	privateKeyPEM = pem.EncodeToMemory(block)
+
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		return nil, nil, fmt.Errorf("create ssh public key: %w", err)
+	}
+	publicKey = ssh.MarshalAuthorizedKey(sshPub)
+
+	return publicKey, privateKeyPEM, nil
+}
+
 // SaveKeyPair writes the private and public key files to the given directory.
 // The private key is written with mode 0600 and the public key with mode 0644.
 func SaveKeyPair(dir string, privateKey, publicKey []byte) error {

--- a/control-plane/main.go
+++ b/control-plane/main.go
@@ -28,11 +28,13 @@ import (
 	"github.com/gluk-w/claworc/control-plane/internal/modwiring"
 	"github.com/gluk-w/claworc/control-plane/internal/orchestrator"
 	"github.com/gluk-w/claworc/control-plane/internal/sshaudit"
+	"github.com/gluk-w/claworc/control-plane/internal/sshgateway"
 	"github.com/gluk-w/claworc/control-plane/internal/sshproxy"
 	"github.com/gluk-w/claworc/control-plane/internal/sshterminal"
 	"github.com/gluk-w/claworc/control-plane/internal/taskmanager"
 	"github.com/go-chi/chi/v5"
 	chimw "github.com/go-chi/chi/v5/middleware"
+	"golang.org/x/crypto/ssh"
 )
 
 //go:embed frontend/dist
@@ -177,6 +179,29 @@ func main() {
 	}
 	sshMgr.StartHealthChecker(ctx)
 
+	// Inbound SSH gateway: users `ssh <user>+<instance>@host` and are bridged
+	// onto the existing per-instance SSH connection owned by sshMgr.
+	var sshGw *sshgateway.Gateway
+	if config.Cfg.SSHGatewayEnabled {
+		gwHostKey, err := sshgateway.EnsureHostKey(config.Cfg.DataPath)
+		if err != nil {
+			log.Printf("WARNING: SSH gateway host key: %v", err)
+		} else {
+			sshGw = sshgateway.New(sshgateway.Config{
+				Addr:    fmt.Sprintf(":%d", config.Cfg.SSHGatewayPort),
+				HostKey: gwHostKey,
+				Auditor: auditor,
+				Clients: func(cctx context.Context, inst *database.Instance) (*ssh.Client, error) {
+					return sshMgr.EnsureConnectedWithIPCheck(cctx, inst.ID, orchestrator.Get(), inst.AllowedSourceIPs)
+				},
+			})
+			if err := sshGw.Start(ctx); err != nil {
+				log.Printf("WARNING: SSH gateway failed to start: %v", err)
+				sshGw = nil
+			}
+		}
+	}
+
 	// Build InstanceFactory: resolves an active SSH connection by instance name.
 	instanceFactory := func(fctx context.Context, name string) (sshproxy.Instance, error) {
 		var inst database.Instance
@@ -309,6 +334,11 @@ func main() {
 			r.Post("/auth/webauthn/register/finish", handlers.WebAuthnRegisterFinish)
 			r.Get("/auth/webauthn/credentials", handlers.ListWebAuthnCredentials)
 			r.Delete("/auth/webauthn/credentials/{credId}", handlers.DeleteWebAuthnCredential)
+			r.Post("/auth/ssh-keys/generate", handlers.GenerateUserSSHKey)
+			r.Post("/auth/ssh-keys", handlers.UploadUserSSHKey)
+			r.Get("/auth/ssh-keys", handlers.ListUserSSHKeys)
+			r.Delete("/auth/ssh-keys/{keyId}", handlers.DeleteUserSSHKey)
+			r.Get("/ssh-gateway/info", handlers.GetSSHGatewayInfo)
 		})
 
 		// Protected routes (require auth)
@@ -541,6 +571,9 @@ func main() {
 	log.Println("Shutting down...")
 
 	termMgr.Stop()
+	if sshGw != nil {
+		sshGw.Stop()
+	}
 	tunnelMgr.StopAll()
 
 	if err := sshMgr.CloseAll(); err != nil {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: claworc/claworc:latest
     ports:
       - "8000:8000"
+      - "2222:2222"   # inbound SSH gateway (ssh <user>+<agent>@host)
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - claworc-data:/app/data

--- a/docs/ssh-gateway.md
+++ b/docs/ssh-gateway.md
@@ -1,0 +1,86 @@
+# Inbound SSH Gateway
+
+The SSH gateway (`control-plane/internal/sshgateway/`) lets users connect to
+their OpenClaw instances with a plain SSH client:
+
+```
+ssh -i ~/.ssh/claworc_stan.pem -p 2222 stan+my-agent@claworc.example.com
+```
+
+Because the SSH protocol has no SNI equivalent, the target instance is
+encoded in the SSH login name: `<username>+<instance-name>`. The `bot-`
+prefix of stored instance names may be omitted. `scp` and `sftp` work the
+same way.
+
+## How it works
+
+1. The control plane listens on `CLAWORC_SSH_GATEWAY_PORT` (default 2222)
+   with its own ED25519 host key (`<DATA_PATH>/ssh_gateway_host_key`,
+   generated on first boot).
+2. **Authentication** is by public key only. Users generate an identity from
+   Profile → SSH Access (the server stores only the public key in the
+   `user_ssh_keys` table; the private key is downloaded once and never
+   stored) or upload their own public key. Keys are matched by SHA256
+   fingerprint and verified byte-for-byte. `CLAWORC_AUTH_DISABLED` does not
+   affect the gateway — a key is always required.
+3. **Authorization** reuses the standard RBAC
+   (`database.CanUserAccessInstance`): admins reach every instance, team
+   managers their team's instances, regular members instances with an
+   explicit `UserInstance` grant. A valid key with a missing/unknown/
+   unauthorized instance still authenticates, then receives an explanatory
+   message and exit status 1 (unknown and unauthorized are rendered
+   identically to prevent name enumeration).
+4. **Bridging**: each inbound `session` channel is bridged onto the control
+   plane's existing multiplexed SSH connection to the instance
+   (`SSHManager.EnsureConnectedWithIPCheck`) — the same transport that
+   carries the VNC/LLM/CDP tunnels and web terminals. The gateway never
+   dials its own connection and never closes the shared client; a user
+   session is just one more channel. Sessions land as `root` on the
+   instance, consistent with the existing web terminal and file APIs.
+
+## v1 scope and limits
+
+- `session` channels only: interactive shell, exec, scp, sftp.
+- `direct-tcpip`/`tcpip-forward` (port forwarding) are rejected; the agent
+  sshd's `PermitOpen` allowlist would block arbitrary targets anyway.
+- The agent sshd's `MaxSessions` (OpenSSH default 10) caps concurrent
+  channels per instance, shared with web terminals and tunnels.
+- Brute-force protection: 30s handshake timeout, `MaxAuthTries` 3, per-IP
+  ban (10 failed auths within 1 minute → 5 minute ban), 64 concurrent
+  connection cap.
+
+## Configuration
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `CLAWORC_SSH_GATEWAY_ENABLED` | `true` | Enable the listener |
+| `CLAWORC_SSH_GATEWAY_PORT` | `2222` | Listen port |
+| `CLAWORC_SSH_GATEWAY_PUBLIC_HOST` | (empty) | Display-only hostname for the UI snippet; empty = browser hostname |
+
+Helm: `sshGateway.{enabled,port,servicePort,nodePort,publicHost}` in
+`helm/values.yaml` (adds the container port, env vars, and a Service port).
+Exposure beyond the cluster (LoadBalancer, ingress TCP passthrough) is
+environment-specific.
+
+## API
+
+Authenticated endpoints under `/api/v1`:
+
+- `POST /auth/ssh-keys/generate` → `{key, private_key}` (private key
+  returned exactly once)
+- `POST /auth/ssh-keys` `{name?, public_key}` — upload own key (409 on
+  duplicate fingerprint)
+- `GET /auth/ssh-keys` — list (fingerprints + metadata only)
+- `DELETE /auth/ssh-keys/{keyId}` — revoke (owner-scoped)
+- `GET /ssh-gateway/info` → `{enabled, port, host}`
+
+## Audit events
+
+Recorded in `ssh_audit_logs` (see `internal/sshaudit/`):
+
+- `gateway_login` — successful key auth (details include remote IP,
+  fingerprint, requested instance, deny reason if any)
+- `gateway_login_failed` — failed auth attempt
+- `gateway_session` — shell/exec/subsystem started (exec commands truncated)
+- `gateway_disconnection` — connection closed
+- `key_upload` / `key_rotation` — user key generated/uploaded / revoked

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -26,6 +26,11 @@ spec:
             - name: http
               containerPort: 8000
               protocol: TCP
+            {{- if .Values.sshGateway.enabled }}
+            - name: ssh
+              containerPort: {{ .Values.sshGateway.port }}
+              protocol: TCP
+            {{- end }}
           env:
             - name: CLAWORC_DATA_PATH
               value: {{ .Values.config.dataPath | quote }}
@@ -35,6 +40,16 @@ spec:
             {{- end }}
             - name: CLAWORC_K8S_NAMESPACE
               value: {{ .Values.config.k8sNamespace | quote }}
+            - name: CLAWORC_SSH_GATEWAY_ENABLED
+              value: {{ .Values.sshGateway.enabled | quote }}
+            {{- if .Values.sshGateway.enabled }}
+            - name: CLAWORC_SSH_GATEWAY_PORT
+              value: {{ .Values.sshGateway.port | quote }}
+            {{- if .Values.sshGateway.publicHost }}
+            - name: CLAWORC_SSH_GATEWAY_PUBLIC_HOST
+              value: {{ .Values.sshGateway.publicHost | quote }}
+            {{- end }}
+            {{- end }}
             {{- if .Values.database.existingSecret }}
             - name: CLAWORC_DATABASE
               valueFrom:

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -15,5 +15,14 @@ spec:
       {{- if and (eq .Values.service.type "NodePort") .Values.service.nodePort }}
       nodePort: {{ .Values.service.nodePort }}
       {{- end }}
+    {{- if .Values.sshGateway.enabled }}
+    - name: ssh
+      port: {{ .Values.sshGateway.servicePort }}
+      targetPort: ssh
+      protocol: TCP
+      {{- if and (eq .Values.service.type "NodePort") .Values.sshGateway.nodePort }}
+      nodePort: {{ .Values.sshGateway.nodePort }}
+      {{- end }}
+    {{- end }}
   selector:
     {{- include "claworc.selectorLabels" . | nindent 4 }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -33,6 +33,17 @@ service:
   port: 8001
   nodePort: 30000
 
+# Inbound SSH gateway: lets users `ssh <user>+<agent-name>@<host>` and be
+# bridged to that agent. publicHost is display-only (the hostname shown in
+# the UI's usage snippet). Exposing the service port beyond the cluster
+# (LoadBalancer, ingress TCP passthrough) is environment-specific.
+sshGateway:
+  enabled: true
+  port: 2222
+  servicePort: 2222
+  nodePort: ""
+  publicHost: ""
+
 persistence:
   enabled: true
   size: 1Gi


### PR DESCRIPTION
## Summary

- Inbound SSH gateway (`internal/sshgateway/`, default port 2222): users run `ssh <user>+<agent-name>@host`; instance selection is encoded in the SSH login name
- Authenticates against per-user public keys; per-user identity files generated from the profile page (private key downloaded once, never stored; OpenSSH-native key format)
- Authorization reuses existing RBAC via new `database.CanUserAccessInstance` (middleware now delegates to it)
- Sessions are bridged as new channels on the existing per-instance SSH connection owned by SSHManager — no second connection; supports shell/exec/scp/sftp, rejects port forwarding (v1)
- Helpful in-session errors: missing/unknown instance prints usage plus the user's accessible agents as ready-to-copy login names
- Key management API under `/api/v1/auth/ssh-keys` + "SSH Access" card on the profile page (generate, fingerprint list, revoke)
- Audit events (gateway_login/_failed, gateway_session, gateway_disconnection) in `ssh_audit_logs`; per-IP brute-force banning
- Helm (`sshGateway.*` values, container/Service ports), docker-compose port 2222, `docs/ssh-gateway.md`

## Testing

- `go build . ./internal/...` clean; full `go test ./internal/... .` green, including integration tests (real ssh client through the gateway to a fake sshd, OpenSSH-binary compat tests, connection-reuse assertion)
- Frontend: `npx vite build` clean
- `helm template helm/` renders OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bq7kWLiGRLWy62xEGmrQpW