### PR TITLE
fix(ci): Fix nightly agent image build: strip upstream hooks catalog from config snapshot

### DIFF
--- a/agent/tests/openclaw.test.ts
+++ b/agent/tests/openclaw.test.ts
@@ -96,15 +96,17 @@ describe.skipIf(!container)("agent image", { timeout: 300_000 }, () => {
     expect(result.exitCode).toBe(0);
 
     const config = JSON.parse(result.stdout);
-    // Strip upstream-owned plugin/skill catalogs entirely. They're not
+    // Strip upstream-owned plugin/skill/hook catalogs entirely. They're not
     // schema we depend on, they change weekly as openclaw adds/removes
-    // built-ins, and they're shaped completely differently between
+    // built-ins (e.g. 2026.7.x added `hooks.internal.entries.session-memory`),
+    // and they're shaped completely differently between
     // `openclaw@latest` (uses `skills.entries.*`) and `openclaw@stable`
     // (uses `plugins.entries.*`) — so a single snapshot can't track both.
     // The stable parts of the config (gateway, browser, agents, meta, ...)
     // are what our integration actually cares about.
     delete config.skills;
     delete config.plugins;
+    delete config.hooks;
     expect(structureOf(config)).toMatchSnapshot();
   });
 


### PR DESCRIPTION
OpenClaw 2026.7.x started writing hooks.internal.entries.session-memory into openclaw.json, which broke the structure snapshot test and has blocked the nightly image publish since 2026-07-14. Treat hooks like the skills/plugins catalogs the test already strips: upstream-owned, churns with releases, not schema Claworc depends on.