### PR TITLE
fix(k8s): pin SELinux MCS level on browser and copy pods sharing instance PVCs

### DIFF
--- a/control-plane/internal/orchestrator/kubernetes.go
+++ b/control-plane/internal/orchestrator/kubernetes.go
@@ -27,6 +27,12 @@ import (
 	"k8s.io/client-go/util/homedir"
 )
 
+// seLinuxMCSLevel is the fixed SELinux MCS level shared by every claworc pod
+// that mounts an instance PVC. Pinning it keeps the runtime from assigning
+// random per-pod categories and relabeling shared volumes out from under
+// sibling pods (agent <-> browser <-> copy pods). No-op on non-SELinux nodes.
+const seLinuxMCSLevel = "s0:c0,c0"
+
 type KubernetesOrchestrator struct {
 	clientset       kubernetes.Interface
 	restConfig      *rest.Config
@@ -195,6 +201,11 @@ func (k *KubernetesOrchestrator) copyPVC(ctx context.Context, srcPVC, dstPVC str
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
+			// Pin the MCS level so mounting the PVCs here doesn't relabel
+			// them away from what instance/browser pods expect.
+			SecurityContext: &corev1.PodSecurityContext{
+				SELinuxOptions: &corev1.SELinuxOptions{Level: seLinuxMCSLevel},
+			},
 			Containers: []corev1.Container{{
 				Name:    "copy",
 				Image:   "alpine:latest",
@@ -708,7 +719,7 @@ func buildDeployment(params CreateParams, ns string) *appsv1.Deployment {
 						// SELinux policies deny access to the agent's own
 						// home dir on restart. Ignored on non-SELinux nodes.
 						SELinuxOptions: &corev1.SELinuxOptions{
-							Level: "s0:c0,c0",
+							Level: seLinuxMCSLevel,
 						},
 						FSGroup:             &fsGroup,
 						FSGroupChangePolicy: &fsGroupPolicy,
@@ -770,7 +781,7 @@ func buildInitContainers(sfMounts []SharedFolderMount, privileged bool) []corev1
 		// chcon may fail on non-SELinux nodes — || true keeps the pod startable.
 		// Errors are intentionally left on stderr so they appear in pod logs.
 		Command: []string{"sh", "-c",
-			"chcon -R -l s0:c0,c0 /home/claworc /home/linuxbrew/.linuxbrew || true"},
+			"chcon -R -l " + seLinuxMCSLevel + " /home/claworc /home/linuxbrew/.linuxbrew || true"},
 		SecurityContext: &corev1.SecurityContext{Privileged: &privileged},
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: "home-data", MountPath: "/home/claworc"},

--- a/control-plane/internal/orchestrator/kubernetes_apply.go
+++ b/control-plane/internal/orchestrator/kubernetes_apply.go
@@ -401,10 +401,16 @@ func buildDeploymentFromSpec(ns string, spec WorkloadSpec) *appsv1.Deployment {
 	}
 
 	podSpec := corev1.PodSpec{
-		Hostname:         spec.Hostname,
-		Containers:       []corev1.Container{mainContainer},
-		InitContainers:   initContainers,
-		Volumes:          volumes,
+		Hostname:       spec.Hostname,
+		Containers:     []corev1.Container{mainContainer},
+		InitContainers: initContainers,
+		Volumes:        volumes,
+		// Applied workloads (e.g. browser pods) share the agent's home PVC.
+		// Without a pinned MCS level the runtime picks a random category and
+		// relabels the shared volume, breaking the agent pod with EACCES.
+		SecurityContext: &corev1.PodSecurityContext{
+			SELinuxOptions: &corev1.SELinuxOptions{Level: seLinuxMCSLevel},
+		},
 		ImagePullSecrets: []corev1.LocalObjectReference{{Name: "ghcr-secret"}},
 	}
 	if spec.Affinity != nil && len(spec.Affinity.RequiredCoLocation) > 0 {

--- a/control-plane/internal/orchestrator/kubernetes_apply_test.go
+++ b/control-plane/internal/orchestrator/kubernetes_apply_test.go
@@ -113,6 +113,27 @@ func TestApply_CreatesPVC_DeploymentService_NetworkPolicy(t *testing.T) {
 	}
 }
 
+func TestApply_PinsSELinuxLevel(t *testing.T) {
+	k := newFakeOrchestrator(t)
+	ctx := context.Background()
+
+	if err := k.Apply(ctx, browserSpec()); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	dep, err := k.clientset.AppsV1().Deployments("claworc").Get(ctx, "bot-foo-browser", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get deployment: %v", err)
+	}
+	sc := dep.Spec.Template.Spec.SecurityContext
+	if sc == nil || sc.SELinuxOptions == nil {
+		t.Fatalf("pod SecurityContext.SELinuxOptions not set; applied workloads share the agent home PVC and must pin the MCS level")
+	}
+	if got := sc.SELinuxOptions.Level; got != seLinuxMCSLevel {
+		t.Errorf("SELinux level = %q, want %q", got, seLinuxMCSLevel)
+	}
+}
+
 func TestApply_IsIdempotent_OnReapply(t *testing.T) {
 	k := newFakeOrchestrator(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Problem

On SELinux-enforcing nodes, running agents intermittently crash-loop with `EACCES: permission denied` on their own home directory. Root cause: the main instance pod pins `seLinuxOptions.level: s0:c0,c0`, but the companion `<bot>-browser` deployment mounts the **same** `<name>-home` PVC (Downloads subpath) with no pod SecurityContext. When the browser pod starts, the runtime assigns it a random MCS category and relabels the entire shared volume, breaking the agent pod — which may not have restarted at all. Manual `chcon` from inside a pod is blocked by node policy, so the only recovery was a full pod recreation.

## Changes

- Pod-level `seLinuxOptions.level: s0:c0,c0` on all workloads built via the apply path (covers browser pods), set unconditionally in the K8s backend rather than plumbed through the runtime-agnostic `WorkloadSpec`
- Same pinning on the ad-hoc `copyPVC` volume-clone pod, which had the identical gap
- Hardcoded `s0:c0,c0` literals consolidated into a single `seLinuxMCSLevel` constant
- Test asserting applied deployments carry the pinned level

Rollout is self-healing: existing browser deployments pick up the SecurityContext on the next `EnsureSession` re-apply, and the resulting Recreate rollout's mount-time relabel repairs any currently mislabeled home PVC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw4zkH3XS29z2Y9ru5bMcF