### PR TITLE
fix(sshgateway): use dot separator for inbound SSH login names

### DIFF
--- a/control-plane/frontend/src/app/pages/AccountPage.tsx
+++ b/control-plane/frontend/src/app/pages/AccountPage.tsx
@@ -320,7 +320,7 @@ function SSHKeyGeneratedDialog({
   onClose: () => void;
 }) {
   const portFlag = gatewayPort && gatewayPort !== 22 ? ` -p ${gatewayPort}` : "";
-  const sshCommand = `ssh -i ~/.ssh/${keyFileName}${portFlag} ${username || "<you>"}+<agent-name>@${gatewayHost}`;
+  const sshCommand = `ssh -i ~/.ssh/${keyFileName}${portFlag} ${username || "<you>"}.<agent-name>@${gatewayHost}`;
 
   return (
     <div

--- a/control-plane/internal/sshgateway/auth_test.go
+++ b/control-plane/internal/sshgateway/auth_test.go
@@ -132,15 +132,15 @@ func TestAuthenticate(t *testing.T) {
 		wantDeny   string
 		wantInstID bool
 	}{
-		{"admin full access", "admin+my-agent", adminKey, false, "", true},
-		{"admin with bot prefix", "admin+bot-my-agent", adminKey, false, "", true},
-		{"team manager", "manager+my-agent", managerKey, false, "", true},
-		{"granted member", "member+my-agent", memberKey, false, "", true},
-		{"ungranted team user", "stranger+my-agent", strangerKey, false, denyUnknownInstance, false},
-		{"unknown instance", "admin+nope", adminKey, false, denyUnknownInstance, false},
+		{"admin full access", "admin.my-agent", adminKey, false, "", true},
+		{"admin with bot prefix", "admin.bot-my-agent", adminKey, false, "", true},
+		{"team manager", "manager.my-agent", managerKey, false, "", true},
+		{"granted member", "member.my-agent", memberKey, false, "", true},
+		{"ungranted team user", "stranger.my-agent", strangerKey, false, denyUnknownInstance, false},
+		{"unknown instance", "admin.nope", adminKey, false, denyUnknownInstance, false},
 		{"missing instance", "admin", adminKey, false, denyMissingInstance, false},
-		{"unknown user", "ghost+my-agent", adminKey, true, "", false},
-		{"wrong user's key", "admin+my-agent", strangerKey, true, "", false},
+		{"unknown user", "ghost.my-agent", adminKey, true, "", false},
+		{"wrong user's key", "admin.my-agent", strangerKey, true, "", false},
 	}
 
 	for _, tt := range tests {
@@ -176,7 +176,7 @@ func TestAuthenticateUnregisteredKey(t *testing.T) {
 	}
 	signer, _ := ssh.ParsePrivateKey(privKeyPEM)
 
-	if _, err := g.authenticate(fakeConnMetadata{user: "alice+x"}, signer.PublicKey()); err == nil {
+	if _, err := g.authenticate(fakeConnMetadata{user: "alice.x"}, signer.PublicKey()); err == nil {
 		t.Fatal("expected error for unregistered key")
 	}
 }

--- a/control-plane/internal/sshgateway/bridge.go
+++ b/control-plane/internal/sshgateway/bridge.go
@@ -200,7 +200,7 @@ func (g *Gateway) denySession(sc *ssh.ServerConn, in ssh.Channel, inReqs <-chan 
 	username := sc.Permissions.Extensions[extUsername]
 	msg := "claworc: instance not found or not authorized\r\n"
 	if reason == denyMissingInstance {
-		msg = fmt.Sprintf("claworc: no instance specified. Connect as %s+<instance-name>@<host>\r\n", username)
+		msg = fmt.Sprintf("claworc: no instance specified. Connect as %s.<instance-name>@<host>\r\n", username)
 	}
 
 	userID := permsUint(sc.Permissions, extUserID)
@@ -208,7 +208,7 @@ func (g *Gateway) denySession(sc *ssh.ServerConn, in ssh.Channel, inReqs <-chan 
 		if names := accessibleInstanceNames(userID, user.Role == "admin"); len(names) > 0 {
 			msg += "\r\nYour agents:\r\n"
 			for _, name := range names {
-				msg += fmt.Sprintf("  %s+%s\r\n", username, name)
+				msg += fmt.Sprintf("  %s.%s\r\n", username, name)
 			}
 		}
 	}

--- a/control-plane/internal/sshgateway/gateway.go
+++ b/control-plane/internal/sshgateway/gateway.go
@@ -1,5 +1,5 @@
 // Package sshgateway implements the inbound SSH gateway: users connect with
-// `ssh <username>+<instance>@<claworc-host>`, authenticate with a per-user
+// `ssh <username>.<instance>@<claworc-host>`, authenticate with a per-user
 // public key registered in Claworc, and their session is bridged onto the
 // control plane's existing multiplexed SSH connection to the target instance.
 // The gateway never dials its own connection to an agent — it only opens new
@@ -130,7 +130,7 @@ func (g *Gateway) serverConfig() *ssh.ServerConfig {
 		PublicKeyCallback: g.authenticate,
 		BannerCallback: func(cm ssh.ConnMetadata) string {
 			if _, instance := ParseSSHUser(cm.User()); instance == "" {
-				return "claworc: connect as <username>+<instance-name>@<host>\r\n"
+				return "claworc: connect as <username>.<instance-name>@<host>\r\n"
 			}
 			return ""
 		},

--- a/control-plane/internal/sshgateway/gateway_test.go
+++ b/control-plane/internal/sshgateway/gateway_test.go
@@ -227,7 +227,7 @@ func (e *testEnv) dial(t *testing.T, sshUser string, signer ssh.Signer) *ssh.Cli
 
 func TestGatewayExecBridging(t *testing.T) {
 	env := setupGateway(t)
-	client := env.dial(t, "stan+my-agent", env.signer)
+	client := env.dial(t, "stan.my-agent", env.signer)
 
 	sess, err := client.NewSession()
 	if err != nil {
@@ -246,7 +246,7 @@ func TestGatewayExecBridging(t *testing.T) {
 
 func TestGatewayExitStatusForwarded(t *testing.T) {
 	env := setupGateway(t)
-	client := env.dial(t, "stan+my-agent", env.signer)
+	client := env.dial(t, "stan.my-agent", env.signer)
 
 	sess, err := client.NewSession()
 	if err != nil {
@@ -266,7 +266,7 @@ func TestGatewayExitStatusForwarded(t *testing.T) {
 
 func TestGatewayConnectionReuse(t *testing.T) {
 	env := setupGateway(t)
-	client := env.dial(t, "stan+my-agent", env.signer)
+	client := env.dial(t, "stan.my-agent", env.signer)
 
 	var wg sync.WaitGroup
 	for i := 0; i < 2; i++ {
@@ -287,7 +287,7 @@ func TestGatewayConnectionReuse(t *testing.T) {
 	wg.Wait()
 
 	// A second inbound SSH connection must also reuse the outbound one.
-	client2 := env.dial(t, "stan+my-agent", env.signer)
+	client2 := env.dial(t, "stan.my-agent", env.signer)
 	sess, err := client2.NewSession()
 	if err != nil {
 		t.Fatalf("new session on second connection: %v", err)
@@ -312,7 +312,7 @@ func TestGatewayWrongKeyRejected(t *testing.T) {
 	otherSigner, _ := ssh.ParsePrivateKey(otherPEM)
 
 	_, err := ssh.Dial("tcp", env.gw.Addr().String(), &ssh.ClientConfig{
-		User:            "stan+my-agent",
+		User:            "stan.my-agent",
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(otherSigner)},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		Timeout:         5 * time.Second,
@@ -344,8 +344,8 @@ func TestGatewayMissingInstanceMessage(t *testing.T) {
 	if !strings.Contains(text, "no instance specified") {
 		t.Errorf("output %q should mention missing instance", text)
 	}
-	if !strings.Contains(text, "stan+my-agent") {
-		t.Errorf("output %q should list copyable login stan+my-agent", text)
+	if !strings.Contains(text, "stan.my-agent") {
+		t.Errorf("output %q should list copyable login stan.my-agent", text)
 	}
 	if env.sshd.connCount.Load() != 0 {
 		t.Errorf("denied session must not touch the agent")
@@ -354,7 +354,7 @@ func TestGatewayMissingInstanceMessage(t *testing.T) {
 
 func TestGatewayUnknownInstance(t *testing.T) {
 	env := setupGateway(t)
-	client := env.dial(t, "stan+nope", env.signer)
+	client := env.dial(t, "stan.nope", env.signer)
 
 	sess, err := client.NewSession()
 	if err != nil {
@@ -369,14 +369,14 @@ func TestGatewayUnknownInstance(t *testing.T) {
 	if !strings.Contains(string(out), "not found or not authorized") {
 		t.Errorf("output %q should be the generic denial", string(out))
 	}
-	if !strings.Contains(string(out), "stan+my-agent") {
+	if !strings.Contains(string(out), "stan.my-agent") {
 		t.Errorf("output %q should list copyable login names", string(out))
 	}
 }
 
 func TestGatewayRejectsDirectTCPIP(t *testing.T) {
 	env := setupGateway(t)
-	client := env.dial(t, "stan+my-agent", env.signer)
+	client := env.dial(t, "stan.my-agent", env.signer)
 
 	// direct-tcpip open must be rejected (v1 supports sessions only).
 	if _, err := client.Dial("tcp", "127.0.0.1:80"); err == nil {
@@ -391,7 +391,7 @@ func TestGatewayRateLimiterBansAfterFailures(t *testing.T) {
 	otherSigner, _ := ssh.ParsePrivateKey(otherPEM)
 
 	cfg := &ssh.ClientConfig{
-		User:            "stan+my-agent",
+		User:            "stan.my-agent",
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(otherSigner)},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		Timeout:         5 * time.Second,
@@ -406,7 +406,7 @@ func TestGatewayRateLimiterBansAfterFailures(t *testing.T) {
 	}
 	// Banned IPs are dropped at accept time even with the right key.
 	if _, err := ssh.Dial("tcp", env.gw.Addr().String(), &ssh.ClientConfig{
-		User:            "stan+my-agent",
+		User:            "stan.my-agent",
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(env.signer)},
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		Timeout:         2 * time.Second,

--- a/control-plane/internal/sshgateway/openssh_compat_test.go
+++ b/control-plane/internal/sshgateway/openssh_compat_test.go
@@ -81,7 +81,7 @@ func TestOpenSSHClientCompat(t *testing.T) {
 	}
 
 	t.Run("exec with exit 0", func(t *testing.T) {
-		out, code := runSSH("stan+my-agent", "hostname")
+		out, code := runSSH("stan.my-agent", "hostname")
 		if code != 0 {
 			t.Errorf("exit code = %d, want 0 (output %q)", code, out)
 		}
@@ -91,7 +91,7 @@ func TestOpenSSHClientCompat(t *testing.T) {
 	})
 
 	t.Run("exit status forwarded", func(t *testing.T) {
-		_, code := runSSH("stan+my-agent", "exit 7")
+		_, code := runSSH("stan.my-agent", "exit 7")
 		if code != 7 {
 			t.Errorf("exit code = %d, want 7", code)
 		}
@@ -115,7 +115,7 @@ func TestOpenSSHClientCompat(t *testing.T) {
 		if err := database.DeleteUserSSHKey(user.ID, key.ID); err != nil && err != gorm.ErrRecordNotFound {
 			t.Fatalf("revoke: %v", err)
 		}
-		out, code := runSSH("stan+my-agent", "hostname")
+		out, code := runSSH("stan.my-agent", "hostname")
 		if code == 0 {
 			t.Errorf("expected failure after key revocation (output %q)", out)
 		}

--- a/control-plane/internal/sshgateway/parse.go
+++ b/control-plane/internal/sshgateway/parse.go
@@ -1,16 +1,24 @@
-// parse.go maps the SSH login name "user+instance" onto a Claworc username
+// parse.go maps the SSH login name "user.instance" onto a Claworc username
 // and a target instance name.
 
 package sshgateway
 
 import "strings"
 
-// ParseSSHUser splits an SSH login name of the form "<username>+<instance>"
-// on the FIRST '+'. An empty instance means the client did not specify one.
-// Instance names are K8s-safe ([a-z0-9-]) and never contain '+'; Claworc
-// usernames containing '+' cannot use the gateway.
+// ParseSSHUser splits an SSH login name of the form "<username>.<instance>"
+// on the LAST '.'. An empty instance means the client did not specify one.
+//
+// Instance names are K8s-safe ([a-z0-9-]) and never contain '.', so the
+// final dot is unambiguously the separator and any dots to its left belong
+// to the username (e.g. "first.last.my-agent" → "first.last" / "my-agent").
+//
+// Because the username half is used for the auth lookup, a user whose
+// username contains a dot must always name an instance: connecting without
+// one ("ssh first.last@host") is mis-parsed as username "first" + instance
+// "last" and fails auth. Such users can still use the gateway fully by
+// naming an instance explicitly.
 func ParseSSHUser(sshUser string) (username, instance string) {
-	if i := strings.IndexByte(sshUser, '+'); i >= 0 {
+	if i := strings.LastIndexByte(sshUser, '.'); i >= 0 {
 		return sshUser[:i], sshUser[i+1:]
 	}
 	return sshUser, ""

--- a/control-plane/internal/sshgateway/parse_test.go
+++ b/control-plane/internal/sshgateway/parse_test.go
@@ -11,12 +11,14 @@ func TestParseSSHUser(t *testing.T) {
 		wantUser     string
 		wantInstance string
 	}{
-		{"stan+my-agent", "stan", "my-agent"},
+		{"stan.my-agent", "stan", "my-agent"},
 		{"stan", "stan", ""},
-		{"stan+", "stan", ""},
-		{"+my-agent", "", "my-agent"},
-		{"stan+bot-my-agent", "stan", "bot-my-agent"},
-		{"a+b+c", "a", "b+c"},
+		{"stan.", "stan", ""},
+		{".my-agent", "", "my-agent"},
+		{"stan.bot-my-agent", "stan", "bot-my-agent"},
+		// Split on the LAST dot: dots to its left belong to the username.
+		{"a.b.c", "a.b", "c"},
+		{"stan.smith.my-agent", "stan.smith", "my-agent"},
 		{"", "", ""},
 	}
 	for _, tt := range tests {

--- a/docs/ssh-gateway.md
+++ b/docs/ssh-gateway.md
@@ -4,13 +4,15 @@ The SSH gateway (`control-plane/internal/sshgateway/`) lets users connect to
 their OpenClaw instances with a plain SSH client:
 
 ```
-ssh -i ~/.ssh/claworc_stan.pem -p 2222 stan+my-agent@claworc.example.com
+ssh -i ~/.ssh/claworc_stan.pem -p 2222 stan.my-agent@claworc.example.com
 ```
 
 Because the SSH protocol has no SNI equivalent, the target instance is
-encoded in the SSH login name: `<username>+<instance-name>`. The `bot-`
-prefix of stored instance names may be omitted. `scp` and `sftp` work the
-same way.
+encoded in the SSH login name: `<username>.<instance-name>`. The separator
+is the **last** dot — instance names are K8s-safe (`[a-z0-9-]`) and never
+contain a dot, so a username that itself contains dots (e.g. `first.last`)
+still resolves correctly (`first.last.my-agent`). The `bot-` prefix of
+stored instance names may be omitted. `scp` and `sftp` work the same way.
 
 ## How it works
 


### PR DESCRIPTION
## Summary

Switches the inbound SSH gateway login-name separator from `+` to `.`, so users connect with `ssh <user>.<instance>@<host>` instead of `ssh <user>+<instance>@<host>`.

- Parser now splits on the **last** `.` instead of the first `+`. Instance names are K8s-safe (`[a-z0-9-]`, never contain a dot), so the final dot is the unambiguous separator and usernames containing dots (e.g. `first.last`) resolve correctly when an instance is named.
- Updated user-facing hint strings (gateway/bridge) and the Account page SSH snippet to the new `.` form.
- Refreshed `docs/ssh-gateway.md` examples and prose.
- Tests updated across the sshgateway package to cover the dot-splitting behavior.

## Trade-off

A user whose username contains a dot who connects **without** naming an instance (the discovery flow) will misparse and fail auth — but can still use the gateway fully by naming an instance. This is strictly better than the old `+` rule, under which usernames containing `+` could not use the gateway at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw4zkH3XS29z2Y9ru5bMcF