### PR TITLE
fix(deps): pin golang.org/x/crypto to v0.51.0 to avoid sshproxy keepalive deadlock

### DIFF
--- a/control-plane/go.mod
+++ b/control-plane/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/robfig/cron/v3 v3.0.1
-	golang.org/x/crypto v0.52.0
+	golang.org/x/crypto v0.51.0 // do not bump to v0.52.0: its ssh mux holds a mutex across SendRequest reply-wait, deadlocking sshproxy keepalive (see manager.go keepalive/IsConnected)
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/driver/mysql v1.6.0
 	gorm.io/driver/postgres v1.6.0

--- a/control-plane/go.sum
+++ b/control-plane/go.sum
@@ -216,8 +216,8 @@ go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN8
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.52.0 h1:RMs7fP2rXdep0CftQlK8Uf+kibLm7qkCcradZWYz988=
-golang.org/x/crypto v0.52.0/go.mod h1:1QgfPxDqh0T2M/elOJtp9RvuR95kVjir0e6/BvEmGbc=
+golang.org/x/crypto v0.51.0 h1:IBPXwPfKxY7cWQZ38ZCIRPI50YLeevDLlLnyC5wRGTI=
+golang.org/x/crypto v0.51.0/go.mod h1:8AdwkbraGNABw2kOX6YFPs3WM22XqI4EXEd8g+x7Oc8=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=


### PR DESCRIPTION
## Summary

Pins `golang.org/x/crypto` back to **v0.51.0** to fix a hard deadlock in the SSH proxy that is currently breaking main's CI.

- `golang.org/x/crypto` **v0.52.0** (landed via dependabot #183 today) changed the ssh mux to hold an internal mutex across the `SendRequest` reply-wait. On a dead connection this deadlocks `SSHManager.keepalive` against `IsConnected`, hanging the `internal/sshproxy` tests for the full 10-minute CI timeout and failing both Unit Tests and Integration Tests on main.
- Pinned to **v0.51.0**, the minimal safe version — v0.50.0 is not selectable because an indirect dependency requires x/crypto >= v0.51.0. An inline `go.mod` comment documents why not to re-bump to v0.52.0.
- Verified locally: `internal/sshproxy` tests pass in ~5s on v0.51.0 (were hanging on v0.52.0); `go build ./internal/...` OK; `go mod tidy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nw4zkH3XS29z2Y9ru5bMcF