### PR TITLE
fix(migrations): add noop migration for pod placement columns

### DIFF
--- a/control-plane/internal/database/migrations/migration_00010_noop_pod_placement.go
+++ b/control-plane/internal/database/migrations/migration_00010_noop_pod_placement.go
@@ -1,0 +1,31 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+// 00010_noop_pod_placement: registry placeholder for the new pod placement
+// columns (pod_annotations, node_selector, tolerations, affinity) added to
+// the Instance model for K8s pod placement configuration.
+//
+// Per docs/migrations.md, additive columns are handled by AutoMigrateAll on
+// boot and do not require a Goose migration. However, the CI "Migration
+// Drift Check" guard in .github/workflows/control-plane.yml errors out
+// whenever models/models.go changes without a new migration file, so we
+// register a no-op here to satisfy that guard and keep the goose registry
+// contiguous.
+func init() {
+	register(&goose.Migration{
+		Version: 10,
+		Source:  "00010_noop_pod_placement.go",
+		UpFnContext: func(ctx context.Context, tx *sql.Tx) error {
+			return nil
+		},
+		DownFnContext: func(ctx context.Context, tx *sql.Tx) error {
+			return nil
+		},
+	})
+}


### PR DESCRIPTION
## Problem

The **Migration Drift Check** on `main` is failing (run [30459531051](https://github.com/gluk-w/claworc/actions/runs/30459531051)).

PR #196 (`feat(k8s): pod placement config`) added four columns to the `Instance` model — `pod_annotations`, `node_selector`, `tolerations`, `affinity` — without a migration file. The `migrationcheck` itself passes (these are additive columns handled by `AutoMigrateAll` on boot), but the CI guard "Guard against model changes without a new migration" errors out whenever `models/models.go` changes with no new `migration_*.go`.

## Fix

Register a no-op migration (`v10`) to satisfy the guard, following the existing `00008`/`00009` noop pattern used for prior additive/AutoMigrate-handled changes.

- `migrationcheck` passes: schema matches models through v10.
- The guard passes: this change touches no models file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)