### PR TITLE
fix(models): update OpenAI Codex ChatGPT model to gpt-5.6-sol (#186)

### DIFF
--- a/models.csv
+++ b/models.csv
@@ -1,5 +1,5 @@
 provider_key,provider_label,icon_key,api_format,base_url,model_id,model_name,reasoning,vision,context_window,max_tokens,input_cost,output_cost,cached_read_cost,cached_write_cost,tag,description
-openai-codex,OpenAI Codex (ChatGPT subscription),openai,openai-codex-responses,https://chatgpt.com/backend-api,gpt-5.3-codex,GPT-5.3 Codex,TRUE,FALSE,400000,128000,0,0,0,0,coding,Included with ChatGPT subscription
+openai-codex,OpenAI Codex (ChatGPT subscription),openai,openai-codex-responses,https://chatgpt.com/backend-api,gpt-5.6-sol,GPT-5.6 Sol,TRUE,FALSE,400000,128000,0,0,0,0,coding,Included with ChatGPT subscription
 bedrock,Amazon Bedrock,bedrock,bedrock-converse-stream,https://bedrock-runtime.us-east-1.amazonaws.com,us.anthropic.claude-opus-4-6-v1:0,Claude Opus 4.6 (Bedrock),TRUE,TRUE,200000,128000,,,,,,
 anthropic,Anthropic,anthropic,anthropic-messages,https://api.anthropic.com/,claude-opus-4-6,Claude Opus 4.6,TRUE,TRUE,200000,128000,5,25,0.5,6.25,flagship,Most capable — deep reasoning, complex tasks
 anthropic,Anthropic,anthropic,anthropic-messages,https://api.anthropic.com/,claude-sonnet-4-6,Claude Sonnet 4.6,TRUE,TRUE,200000,64000,3,15,0.3,3.75,balanced,Fast & capable — ideal default


### PR DESCRIPTION
## Summary

Fixes #186.

The **OpenAI Codex (ChatGPT subscription)** provider was pinned to `gpt-5.3-codex`, which OpenAI has retired on the ChatGPT Codex (`openai-codex-responses`) endpoint. Requests fail with:

> HTTP 400 — `{"detail":"The 'gpt-5.3-codex' model is not supported when using Codex with a ChatGPT account."}`

Per [OpenAI's Codex model docs](https://learn.chatgpt.com/docs/models), Codex on **ChatGPT-account auth** rejects every `-codex`-suffixed slug (`gpt-5.3-codex`, `gpt-5.2-codex`, …). The models it accepts are `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` / `gpt-5.3-codex-spark` (recommended) and `gpt-5.5` / `gpt-5.4` / `gpt-5.4-mini`. There is no `gpt-5.5-codex`. The documented default when no model is specified is **`gpt-5.6-sol`**, so the provider is pointed at that.

## Changes

- `models.csv`: codex catalog row `model_id` `gpt-5.3-codex` → `gpt-5.6-sol`, `model_name` `GPT-5.3 Codex` → `GPT-5.6 Sol`. Endpoint, api format (`openai-codex-responses`), context window and pricing unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)