### PR TITLE
fix(worker): align @cloudflare/workers-types with wrangler's peer range

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,11 @@ worker-deploy: worker-build-models
 	cd website/worker && npx wrangler deploy
 
 worker-test:
-	cd website/worker && npm install && npx vitest run
+	# npm ci, not npm install: install re-resolves and can silently pick up a
+	# floating peer that the lockfile never sanctioned. That is how this target
+	# broke — wrangler's peerOptional @cloudflare/workers-types drifted ahead of
+	# the pinned major and every run started failing with ERESOLVE.
+	cd website/worker && npm ci && npx vitest run
 
 # Astro marketing site (claworc.com). Deployed as a Cloudflare Worker via
 # website/wrangler.toml — independent of website/worker/ (the providers API).

--- a/website/worker/package-lock.json
+++ b/website/worker/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "claworc-providers-worker",
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20250224.0",
+        "@cloudflare/workers-types": "^5.20260801.1",
         "typescript": "^5.8.2",
         "vitest": "^4.1.2",
         "wrangler": "^4.120.0"
@@ -124,9 +124,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260628.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260628.1.tgz",
-      "integrity": "sha512-fMy5zBnNl/PxGqDzSOQb1TdqyR1sRT1Z7T4F8/cqtxpZ1w8VkejWi0qUH7GZE0I2gJyapdP0oW4pNZfxUbekmw==",
+      "version": "5.20260827.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-5.20260827.1.tgz",
+      "integrity": "sha512-L5wIIHcgy67AAfe8nNmfcRHLBtO+2jva14zx1HxH2tunlteNmQvo4nYtcfef1n1MKXu3Z3xB98Fvl1BorkjFtg==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -737,9 +737,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -757,9 +754,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -777,9 +771,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -797,9 +788,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -817,9 +805,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -837,9 +822,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -857,9 +839,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -877,9 +856,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -897,9 +873,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -923,9 +896,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -949,9 +919,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -975,9 +942,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1001,9 +965,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1027,9 +988,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1053,9 +1011,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1079,9 +1034,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [

--- a/website/worker/package.json
+++ b/website/worker/package.json
@@ -7,7 +7,7 @@
     "test": "vitest run"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20250224.0",
+    "@cloudflare/workers-types": "^5.20260801.1",
     "typescript": "^5.8.2",
     "vitest": "^4.1.2",
     "wrangler": "^4.120.0"


### PR DESCRIPTION
## The failure

`make worker-test` has been failing on `main` since **2026-07-30** (`a047ef2`, widened at `b5fabdd`):

```
npm error While resolving: wrangler@4.120.0
npm error Found: @cloudflare/workers-types@4.20260628.1
npm error Could not resolve dependency:
npm error peerOptional @cloudflare/workers-types@"^5.20260801.1" from wrangler@4.120.0
```

`wrangler@4.120.0` wants `@cloudflare/workers-types@^5.20260801.1`; `website/worker` pinned `^4.20250224.0`.

## Why it drifted

The types package is a **`peerOptional`**, so Dependabot bumps `wrangler` without ever co-bumping it. The two slid apart and the target has been broken ever since.

## The fix

Bump to `^5.20260801.1` and regenerate the lockfile.

- 15/15 vitest tests pass
- `npx tsc --noEmit` reports the **same 9 pre-existing errors** on both v4 and v5 (mostly `tinybench` lib noise), so this isn't hiding a typecheck regression — and `tsc` isn't run by CI anyway

Note that **`npm ci` alone would not have fixed this**: the committed lockfile already encoded the conflict, so it failed with the same ERESOLVE. The version bump is the actual fix.

## Also: `npm install` → `npm ci` in the target

`npm install` re-resolves and can silently pick up a floating peer the lockfile never sanctioned — precisely how this broke. `npm ci` installs exactly what the lockfile says and fails loudly if `package.json` and the lockfile disagree.

Verified end to end: `make worker-test` (the exact command CI runs) passes.

## Not fixed here

The repo has no `.github/dependabot.yml` — Dependabot is configured through the GitHub UI — so `wrangler` and `@cloudflare/workers-types` can't be grouped from the repo. **Without that grouping this will recur on the next wrangler major.** Worth adding a config file or grouping them in the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NjSNLLoNzyDM2Z1X1HPaMe
